### PR TITLE
[Feat] 코스인포페이지 coursedata, sketchmap ➡️ json / coursereview ➡️ api 연동

### DIFF
--- a/src/apis/course/courseInfo/CourseReviewApi.tsx
+++ b/src/apis/course/courseInfo/CourseReviewApi.tsx
@@ -39,7 +39,7 @@ export const courseReviewApi = {
     const apiSortType = sortTypeMap[type];
     const headers = getAuthHeader();
     const response = await axios.get(`${baseURL}/api/course/review/${course_id}?sortType=${apiSortType}`, { headers });
-    console.log("코스 리뷰 조회 결과:", response.data);
+    // console.log("코스 리뷰 조회 결과:", response.data);
     return response.data.result;
   },
 };

--- a/src/apis/course/courseInfo/CourseReviewApi.tsx
+++ b/src/apis/course/courseInfo/CourseReviewApi.tsx
@@ -1,0 +1,45 @@
+import axios from "axios";
+
+const baseURL = import.meta.env.VITE_APP_BASE_URL;
+
+export type CourseReviewItem = {
+  id: number;
+  title: string;
+  level: string;
+  description: string;
+  imgUrl: string;
+  isLiked: boolean;
+};
+
+// 토큰 가져오기
+const getToken = () => {
+  const token = localStorage.getItem("token");
+  //   console.log("가져온 토큰:", token);
+  return token;
+};
+
+// 토큰을 헤더에 추가
+const getAuthHeader = () => {
+  const token = getToken();
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  };
+  //   console.log("생성된 헤더:", headers);
+  return headers;
+};
+
+// filter 값 한글 → 영문 매핑 로직
+const sortTypeMap: Record<string, "latest" | "likes"> = {
+  최신순: "latest",
+  인기순: "likes",
+};
+
+export const courseReviewApi = {
+  getCourseReview: async (course_id: number, type: string): Promise<CourseReviewItem[]> => {
+    const apiSortType = sortTypeMap[type];
+    const headers = getAuthHeader();
+    const response = await axios.get(`${baseURL}/api/course/review/${course_id}?sortType=${apiSortType}`, { headers });
+    console.log("코스 리뷰 조회 결과:", response.data);
+    return response.data.result;
+  },
+};

--- a/src/components/common/card/styled.ts
+++ b/src/components/common/card/styled.ts
@@ -33,6 +33,7 @@ export const CardContainer = styled.div<{ $imgUrl?: string }>`
 
 export const CardContent = styled.div<{ $hasImage?: boolean }>`
   position: absolute;
+  top: 0;
   bottom: 0;
   left: 0;
   right: 0;

--- a/src/components/common/modal/styled.ts
+++ b/src/components/common/modal/styled.ts
@@ -10,7 +10,7 @@ const slideUp = keyframes`
 `;
 
 export const ModalOverlay = styled.div`
-  position: absolute;
+  position: fixed;
   width: 100%;
   height: 100%;
   top: 0;

--- a/src/components/course/courseInfo/CourseData.tsx
+++ b/src/components/course/courseInfo/CourseData.tsx
@@ -1,37 +1,27 @@
 import { useState } from "react";
+import { useParams } from "react-router-dom";
 import { Modal } from "../../common/modal/Modal";
 import { GreenBtn } from "../../common/button/GreenBtn";
 import { LevelComp } from "../../common/item/Level";
 import * as Styled from "./CourseData.styled";
-import mntData from "../../../data/mnt/가리산/가리산_1.json";
 import useKakaoShare from "../../../hooks/useKakaoShare";
-
-// 타입 가드 함수 - json 형식
-function isMountainData(data: unknown): data is typeof mntData {
-  const d = data as typeof mntData;
-  return (
-    d !== null &&
-    typeof d === "object" &&
-    typeof d.course_name === "string" &&
-    typeof d.mnt_name === "string" &&
-    typeof d.total_length_km === "string" &&
-    typeof d.max_ele === "number" &&
-    typeof d.total_time === "string" &&
-    typeof d.start_name === "string" &&
-    typeof d.end_name === "string" &&
-    typeof d.level === "string"
-  );
-}
+// import Skeleton from "react-loading-skeleton";
+// import "react-loading-skeleton/dist/skeleton.css";
+import course_ids from "../../../data/course_ids.json";
+import { MountainData } from "../../../types/mountainData";
 
 const CourseData = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { shareCourse } = useKakaoShare();
 
-  // 타입 검사
-  if (!isMountainData(mntData)) {
-    console.error("Invalid mountain data structure:", mntData);
-    return <div>데이터 형식이 올바르지 않습니다.</div>;
-  }
+  const { course_id } = useParams();
+  const id = parseInt(course_id ?? "", 10);
+
+  const mnt_courseId = course_ids.find((item) => Number(item.course_id) === id);
+
+  const mntData = import.meta.glob<MountainData>(`/src/data/mnt/${mnt_courseId?.courseFilePath}`, {
+    eager: true,
+  });
 
   const totalDistance = mntData.total_length_km;
   const totalElevation = `${mntData.max_ele}m`;
@@ -71,6 +61,29 @@ const CourseData = () => {
         />
       )}
       <Styled.Wrapper>
+        <Styled.CourseTitleWrapper>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>
+            <LevelComp $level={courseLevel}>{courseLevel}</LevelComp>
+          </div>
+          <Styled.GreenBtnWrapper>
+            <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
+          </Styled.GreenBtnWrapper>
+        </Styled.CourseTitleWrapper>
+        <Styled.CourseMeta>
+          <Styled.StartToEnd>{courseStartEnd}</Styled.StartToEnd>
+          <Styled.CourseStats>
+            <Styled.CourseStatsItem>
+              <span style={{ color: "#A4A4A4" }}>소요시간</span> {totalDuration}
+            </Styled.CourseStatsItem>
+            <Styled.CourseStatsItem>
+              <span style={{ color: "#A4A4A4" }}>코스길이</span> {totalDistance}
+            </Styled.CourseStatsItem>
+            <Styled.CourseStatsItem>
+              <span style={{ color: "#A4A4A4" }}>고도</span> {totalElevation}
+            </Styled.CourseStatsItem>
+          </Styled.CourseStats>
+        </Styled.CourseMeta>
         <Styled.CourseTitleWrapper>
           <div style={{ display: "flex", alignItems: "center" }}>
             <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>

--- a/src/components/course/courseInfo/CourseData.tsx
+++ b/src/components/course/courseInfo/CourseData.tsx
@@ -5,19 +5,19 @@ import { GreenBtn } from "../../common/button/GreenBtn";
 import { LevelComp } from "../../common/item/Level";
 import * as Styled from "./CourseData.styled";
 import useKakaoShare from "../../../hooks/useKakaoShare";
-import course_ids from "../../../data/course_ids.json";
+import course_ids from "../../../data/course_ids.json"; // 1. course_ids, MountainData import 해주기
 import { MountainData } from "../../../types/mountainData";
 import Skeleton from "react-loading-skeleton";
 
 const CourseData = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [courseData, setCourseData] = useState<MountainData | null>(null);
+  const [courseData, setCourseData] = useState<MountainData | null>(null); // 2. 여기에도 MountainData useState로 설정해줘야 돼요
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const { shareCourse } = useKakaoShare();
 
-  // 여기서부터 course_id로 course_ids.json에서 코스 데이터 경로 가져오기 시작
+  // 3. 여기서부터 course_id로 course_ids.json에서 코스 데이터 경로 가져오기 시작
   const { course_id } = useParams();
   const id = parseInt(course_id ?? "", 10);
 
@@ -26,7 +26,7 @@ const CourseData = () => {
       try {
         setLoading(true);
 
-        // course_ids에서 코스 데이터 경로 찾기
+        // 3-1) course_ids에서 코스 데이터 경로 찾기
         const mnt_course = course_ids.find((item) => Number(item.course_id) === id);
 
         // 유효한 코스를 찾았는지 확인
@@ -38,7 +38,7 @@ const CourseData = () => {
 
         // console.log("Found course path:", mnt_course.courseFilePath);
 
-        // 직접적인 동적 import 방식
+        // 3-2-1) 직접적인 동적 import 방식
         try {
           const dataModule = await import(`../../../data/mnt/${mnt_course.courseFilePath}`);
           setCourseData(dataModule.default);
@@ -46,12 +46,13 @@ const CourseData = () => {
         } catch (importError) {
           console.error("파일 불러오기 실패:", importError);
 
-          // 대체 방법: glob 방식 사용
+          // 3-2-1) 대체 방법: glob 방식 사용
           const modules: Record<string, { default: MountainData }> = import.meta.glob("../../../data/mnt/**/*.json", {
             eager: true,
           });
           // console.log("Available modules:", Object.keys(modules));
 
+          // 3-3) 코스.json 경로지정해서 불러오기
           const targetPath = `../../../data/mnt/${mnt_course.courseFilePath}`;
           const data = modules[targetPath];
 
@@ -73,8 +74,8 @@ const CourseData = () => {
     loadMountainData();
   }, [id]);
 
+  // 4. courseData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
   if (error || !courseData) {
-    // courseData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
     return (
       <Styled.Wrapper>
         <Styled.CourseTitleWrapper>
@@ -102,7 +103,7 @@ const CourseData = () => {
       </Styled.Wrapper>
     );
   }
-  // 여기까지 .. if (!courseData) {} 확인한 후에 courseData 확인하기
+  // 여기까지 .. if (!courseData) {} 확인한 후에 courseData 확인하기 ⬇️ 아래가 5. courseData 객체 사용하기
 
   const totalDistance = courseData.total_length_km;
   const totalElevation = `${courseData.max_ele}m`;

--- a/src/components/course/courseInfo/CourseData.tsx
+++ b/src/components/course/courseInfo/CourseData.tsx
@@ -11,11 +11,13 @@ import Skeleton from "react-loading-skeleton";
 
 const CourseData = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [mntData, setMntData] = useState<MountainData | null>(null);
+  const [courseData, setCourseData] = useState<MountainData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const { shareCourse } = useKakaoShare();
+
+  // 여기서부터 course_id로 course_ids.json에서 코스 데이터 경로 가져오기 시작
   const { course_id } = useParams();
   const id = parseInt(course_id ?? "", 10);
 
@@ -39,7 +41,7 @@ const CourseData = () => {
         // 직접적인 동적 import 방식
         try {
           const dataModule = await import(`../../../data/mnt/${mnt_course.courseFilePath}`);
-          setMntData(dataModule.default);
+          setCourseData(dataModule.default);
           setLoading(false);
         } catch (importError) {
           console.error("파일 불러오기 실패:", importError);
@@ -54,7 +56,7 @@ const CourseData = () => {
           const data = modules[targetPath];
 
           if (data) {
-            setMntData(data.default);
+            setCourseData(data.default);
             setLoading(false);
           } else {
             setError(`코스 데이터를 찾을 수 없습니다: ${mnt_course.courseFilePath}`);
@@ -71,8 +73,8 @@ const CourseData = () => {
     loadMountainData();
   }, [id]);
 
-  if (error || !mntData) {
-    // mntData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
+  if (error || !courseData) {
+    // courseData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
     return (
       <Styled.Wrapper>
         <Styled.CourseTitleWrapper>
@@ -100,14 +102,15 @@ const CourseData = () => {
       </Styled.Wrapper>
     );
   }
+  // 여기까지 .. if (!courseData) {} 확인한 후에 courseData 확인하기
 
-  const totalDistance = mntData.total_length_km;
-  const totalElevation = `${mntData.max_ele}m`;
-  const totalDuration = mntData.total_time;
-  const courseName = mntData.course_name;
-  const courseStartEnd = `${mntData.start_name} ⟷ ${mntData.end_name}`;
-  const courseTitle = `${mntData.mnt_name} ${courseName}`;
-  const courseLevel = mntData.level;
+  const totalDistance = courseData.total_length_km;
+  const totalElevation = `${courseData.max_ele}m`;
+  const totalDuration = courseData.total_time;
+  const courseName = courseData.course_name;
+  const courseStartEnd = `${courseData.start_name} ⟷ ${courseData.end_name}`;
+  const courseTitle = `${courseData.mnt_name} ${courseName}`;
+  const courseLevel = courseData.level;
 
   const handleKakaoShare = () => {
     shareCourse({

--- a/src/components/course/courseInfo/CourseData.tsx
+++ b/src/components/course/courseInfo/CourseData.tsx
@@ -75,7 +75,7 @@ const CourseData = () => {
   }, [id]);
 
   // 4. courseData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
-  if (error || !courseData) {
+  if (error || !courseData || loading) {
     return (
       <Styled.Wrapper>
         <Styled.CourseTitleWrapper>
@@ -142,58 +142,32 @@ const CourseData = () => {
           onLinkShare={handleLinkShare}
         />
       )}
-      {loading ? (
-        <Styled.Wrapper>
-          <Styled.CourseTitleWrapper>
-            <Skeleton width={"100%"} height={"100%"} />
-            <Styled.GreenBtnWrapper>
-              <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
-            </Styled.GreenBtnWrapper>
-          </Styled.CourseTitleWrapper>
-          <Styled.CourseMeta>
-            <Styled.StartToEnd>
-              <Skeleton width={"100%"} height={"100%"} />
-            </Styled.StartToEnd>
-            <Styled.CourseStats>
-              <Styled.CourseStatsItem>
-                <Skeleton width={"100%"} height={"100%"} />
-              </Styled.CourseStatsItem>
-              <Styled.CourseStatsItem>
-                <Skeleton width={"100%"} height={"100%"} />
-              </Styled.CourseStatsItem>
-              <Styled.CourseStatsItem>
-                <Skeleton width={"100%"} height={"100%"} />
-              </Styled.CourseStatsItem>
-            </Styled.CourseStats>
-          </Styled.CourseMeta>
-        </Styled.Wrapper>
-      ) : (
-        <Styled.Wrapper>
-          <Styled.CourseTitleWrapper>
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>
-              <LevelComp $level={courseLevel}>{courseLevel}</LevelComp>
-            </div>
-            <Styled.GreenBtnWrapper>
-              <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
-            </Styled.GreenBtnWrapper>
-          </Styled.CourseTitleWrapper>
-          <Styled.CourseMeta>
-            <Styled.StartToEnd>{courseStartEnd}</Styled.StartToEnd>
-            <Styled.CourseStats>
-              <Styled.CourseStatsItem>
-                <span style={{ color: "#A4A4A4" }}>소요시간</span> {totalDuration}
-              </Styled.CourseStatsItem>
-              <Styled.CourseStatsItem>
-                <span style={{ color: "#A4A4A4" }}>코스길이</span> {totalDistance}
-              </Styled.CourseStatsItem>
-              <Styled.CourseStatsItem>
-                <span style={{ color: "#A4A4A4" }}>고도</span> {totalElevation}
-              </Styled.CourseStatsItem>
-            </Styled.CourseStats>
-          </Styled.CourseMeta>
-        </Styled.Wrapper>
-      )}
+
+      <Styled.Wrapper>
+        <Styled.CourseTitleWrapper>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>
+            <LevelComp $level={courseLevel}>{courseLevel}</LevelComp>
+          </div>
+          <Styled.GreenBtnWrapper>
+            <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
+          </Styled.GreenBtnWrapper>
+        </Styled.CourseTitleWrapper>
+        <Styled.CourseMeta>
+          <Styled.StartToEnd>{courseStartEnd}</Styled.StartToEnd>
+          <Styled.CourseStats>
+            <Styled.CourseStatsItem>
+              <span style={{ color: "#A4A4A4" }}>소요시간</span> {totalDuration}
+            </Styled.CourseStatsItem>
+            <Styled.CourseStatsItem>
+              <span style={{ color: "#A4A4A4" }}>코스길이</span> {totalDistance}
+            </Styled.CourseStatsItem>
+            <Styled.CourseStatsItem>
+              <span style={{ color: "#A4A4A4" }}>고도</span> {totalElevation}
+            </Styled.CourseStatsItem>
+          </Styled.CourseStats>
+        </Styled.CourseMeta>
+      </Styled.Wrapper>
     </>
   );
 };

--- a/src/components/course/courseInfo/CourseData.tsx
+++ b/src/components/course/courseInfo/CourseData.tsx
@@ -8,6 +8,8 @@ import useKakaoShare from "../../../hooks/useKakaoShare";
 import course_ids from "../../../data/course_ids.json"; // 1. course_ids, MountainData import 해주기
 import { MountainData } from "../../../types/mountainData";
 import Skeleton from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+import { SkeletonTheme } from "react-loading-skeleton";
 
 const CourseData = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -77,30 +79,40 @@ const CourseData = () => {
   // 4. courseData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
   if (error || !courseData || loading) {
     return (
-      <Styled.Wrapper>
-        <Styled.CourseTitleWrapper>
-          <Skeleton width={"100%"} height={"100%"} />
-          <Styled.GreenBtnWrapper>
-            <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
-          </Styled.GreenBtnWrapper>
-        </Styled.CourseTitleWrapper>
-        <Styled.CourseMeta>
-          <Styled.StartToEnd>
-            <Skeleton width={"100%"} height={"100%"} />
-          </Styled.StartToEnd>
-          <Styled.CourseStats>
-            <Styled.CourseStatsItem>
-              <Skeleton width={"100%"} height={"100%"} />
-            </Styled.CourseStatsItem>
-            <Styled.CourseStatsItem>
-              <Skeleton width={"100%"} height={"100%"} />
-            </Styled.CourseStatsItem>
-            <Styled.CourseStatsItem>
-              <Skeleton width={"100%"} height={"100%"} />
-            </Styled.CourseStatsItem>
-          </Styled.CourseStats>
-        </Styled.CourseMeta>
-      </Styled.Wrapper>
+      <SkeletonTheme baseColor="#e0e0e0" highlightColor="#f5f5f5">
+        <Styled.Wrapper>
+          <Styled.CourseTitleWrapper>
+            <div style={{ width: "70%", height: "25px" }}>
+              <Skeleton height={25} />
+            </div>
+            <Styled.GreenBtnWrapper>
+              <Skeleton height={25} width={120} />
+            </Styled.GreenBtnWrapper>
+          </Styled.CourseTitleWrapper>
+
+          <Styled.CourseMeta>
+            <Styled.StartToEnd>
+              <Skeleton height={20} width="110px" />
+            </Styled.StartToEnd>
+
+            <Styled.CourseStats
+              style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "25px" }}
+            >
+              <Styled.CourseStatsItem>
+                <Skeleton height={16} width={100} />
+              </Styled.CourseStatsItem>
+
+              <Styled.CourseStatsItem>
+                <Skeleton height={16} width={100} />
+              </Styled.CourseStatsItem>
+
+              <Styled.CourseStatsItem>
+                <Skeleton height={16} width={100} />
+              </Styled.CourseStatsItem>
+            </Styled.CourseStats>
+          </Styled.CourseMeta>
+        </Styled.Wrapper>
+      </SkeletonTheme>
     );
   }
   // 여기까지 .. if (!courseData) {} 확인한 후에 courseData 확인하기 ⬇️ 아래가 5. courseData 객체 사용하기

--- a/src/components/course/courseInfo/CourseData.tsx
+++ b/src/components/course/courseInfo/CourseData.tsx
@@ -1,27 +1,105 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { Modal } from "../../common/modal/Modal";
 import { GreenBtn } from "../../common/button/GreenBtn";
 import { LevelComp } from "../../common/item/Level";
 import * as Styled from "./CourseData.styled";
 import useKakaoShare from "../../../hooks/useKakaoShare";
-// import Skeleton from "react-loading-skeleton";
-// import "react-loading-skeleton/dist/skeleton.css";
 import course_ids from "../../../data/course_ids.json";
 import { MountainData } from "../../../types/mountainData";
+import Skeleton from "react-loading-skeleton";
 
 const CourseData = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { shareCourse } = useKakaoShare();
+  const [mntData, setMntData] = useState<MountainData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
+  const { shareCourse } = useKakaoShare();
   const { course_id } = useParams();
   const id = parseInt(course_id ?? "", 10);
 
-  const mnt_courseId = course_ids.find((item) => Number(item.course_id) === id);
+  useEffect(() => {
+    const loadMountainData = async () => {
+      try {
+        setLoading(true);
 
-  const mntData = import.meta.glob<MountainData>(`/src/data/mnt/${mnt_courseId?.courseFilePath}`, {
-    eager: true,
-  });
+        // course_ids에서 코스 데이터 경로 찾기
+        const mnt_course = course_ids.find((item) => Number(item.course_id) === id);
+
+        // 유효한 코스를 찾았는지 확인
+        if (!mnt_course?.courseFilePath) {
+          setError("코스 정보를 찾을 수 없습니다.");
+          setLoading(false);
+          return;
+        }
+
+        // console.log("Found course path:", mnt_course.courseFilePath);
+
+        // 직접적인 동적 import 방식
+        try {
+          const dataModule = await import(`../../../data/mnt/${mnt_course.courseFilePath}`);
+          setMntData(dataModule.default);
+          setLoading(false);
+        } catch (importError) {
+          console.error("파일 불러오기 실패:", importError);
+
+          // 대체 방법: glob 방식 사용
+          const modules: Record<string, { default: MountainData }> = import.meta.glob("../../../data/mnt/**/*.json", {
+            eager: true,
+          });
+          // console.log("Available modules:", Object.keys(modules));
+
+          const targetPath = `../../../data/mnt/${mnt_course.courseFilePath}`;
+          const data = modules[targetPath];
+
+          if (data) {
+            setMntData(data.default);
+            setLoading(false);
+          } else {
+            setError(`코스 데이터를 찾을 수 없습니다: ${mnt_course.courseFilePath}`);
+            setLoading(false);
+          }
+        }
+      } catch (err) {
+        console.error("데이터 로딩 오류:", err);
+        setError("코스 데이터를 불러오는 중 오류가 발생했습니다.");
+        setLoading(false);
+      }
+    };
+
+    loadMountainData();
+  }, [id]);
+
+  if (error || !mntData) {
+    // mntData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
+    return (
+      <Styled.Wrapper>
+        <Styled.CourseTitleWrapper>
+          <Skeleton width={"100%"} height={"100%"} />
+          <Styled.GreenBtnWrapper>
+            <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
+          </Styled.GreenBtnWrapper>
+        </Styled.CourseTitleWrapper>
+        <Styled.CourseMeta>
+          <Styled.StartToEnd>
+            <Skeleton width={"100%"} height={"100%"} />
+          </Styled.StartToEnd>
+          <Styled.CourseStats>
+            <Styled.CourseStatsItem>
+              <Skeleton width={"100%"} height={"100%"} />
+            </Styled.CourseStatsItem>
+            <Styled.CourseStatsItem>
+              <Skeleton width={"100%"} height={"100%"} />
+            </Styled.CourseStatsItem>
+            <Styled.CourseStatsItem>
+              <Skeleton width={"100%"} height={"100%"} />
+            </Styled.CourseStatsItem>
+          </Styled.CourseStats>
+        </Styled.CourseMeta>
+      </Styled.Wrapper>
+    );
+  }
 
   const totalDistance = mntData.total_length_km;
   const totalElevation = `${mntData.max_ele}m`;
@@ -60,54 +138,58 @@ const CourseData = () => {
           onLinkShare={handleLinkShare}
         />
       )}
-      <Styled.Wrapper>
-        <Styled.CourseTitleWrapper>
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>
-            <LevelComp $level={courseLevel}>{courseLevel}</LevelComp>
-          </div>
-          <Styled.GreenBtnWrapper>
-            <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
-          </Styled.GreenBtnWrapper>
-        </Styled.CourseTitleWrapper>
-        <Styled.CourseMeta>
-          <Styled.StartToEnd>{courseStartEnd}</Styled.StartToEnd>
-          <Styled.CourseStats>
-            <Styled.CourseStatsItem>
-              <span style={{ color: "#A4A4A4" }}>소요시간</span> {totalDuration}
-            </Styled.CourseStatsItem>
-            <Styled.CourseStatsItem>
-              <span style={{ color: "#A4A4A4" }}>코스길이</span> {totalDistance}
-            </Styled.CourseStatsItem>
-            <Styled.CourseStatsItem>
-              <span style={{ color: "#A4A4A4" }}>고도</span> {totalElevation}
-            </Styled.CourseStatsItem>
-          </Styled.CourseStats>
-        </Styled.CourseMeta>
-        <Styled.CourseTitleWrapper>
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>
-            <LevelComp $level={courseLevel}>{courseLevel}</LevelComp>
-          </div>
-          <Styled.GreenBtnWrapper>
-            <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
-          </Styled.GreenBtnWrapper>
-        </Styled.CourseTitleWrapper>
-        <Styled.CourseMeta>
-          <Styled.StartToEnd>{courseStartEnd}</Styled.StartToEnd>
-          <Styled.CourseStats>
-            <Styled.CourseStatsItem>
-              <span style={{ color: "#A4A4A4" }}>소요시간</span> {totalDuration}
-            </Styled.CourseStatsItem>
-            <Styled.CourseStatsItem>
-              <span style={{ color: "#A4A4A4" }}>코스길이</span> {totalDistance}
-            </Styled.CourseStatsItem>
-            <Styled.CourseStatsItem>
-              <span style={{ color: "#A4A4A4" }}>고도</span> {totalElevation}
-            </Styled.CourseStatsItem>
-          </Styled.CourseStats>
-        </Styled.CourseMeta>
-      </Styled.Wrapper>
+      {loading ? (
+        <Styled.Wrapper>
+          <Styled.CourseTitleWrapper>
+            <Skeleton width={"100%"} height={"100%"} />
+            <Styled.GreenBtnWrapper>
+              <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
+            </Styled.GreenBtnWrapper>
+          </Styled.CourseTitleWrapper>
+          <Styled.CourseMeta>
+            <Styled.StartToEnd>
+              <Skeleton width={"100%"} height={"100%"} />
+            </Styled.StartToEnd>
+            <Styled.CourseStats>
+              <Styled.CourseStatsItem>
+                <Skeleton width={"100%"} height={"100%"} />
+              </Styled.CourseStatsItem>
+              <Styled.CourseStatsItem>
+                <Skeleton width={"100%"} height={"100%"} />
+              </Styled.CourseStatsItem>
+              <Styled.CourseStatsItem>
+                <Skeleton width={"100%"} height={"100%"} />
+              </Styled.CourseStatsItem>
+            </Styled.CourseStats>
+          </Styled.CourseMeta>
+        </Styled.Wrapper>
+      ) : (
+        <Styled.Wrapper>
+          <Styled.CourseTitleWrapper>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <Styled.CourseTitle>{courseTitle}</Styled.CourseTitle>
+              <LevelComp $level={courseLevel}>{courseLevel}</LevelComp>
+            </div>
+            <Styled.GreenBtnWrapper>
+              <GreenBtn onClick={() => setIsModalOpen(true)}>코스 공유하기</GreenBtn>
+            </Styled.GreenBtnWrapper>
+          </Styled.CourseTitleWrapper>
+          <Styled.CourseMeta>
+            <Styled.StartToEnd>{courseStartEnd}</Styled.StartToEnd>
+            <Styled.CourseStats>
+              <Styled.CourseStatsItem>
+                <span style={{ color: "#A4A4A4" }}>소요시간</span> {totalDuration}
+              </Styled.CourseStatsItem>
+              <Styled.CourseStatsItem>
+                <span style={{ color: "#A4A4A4" }}>코스길이</span> {totalDistance}
+              </Styled.CourseStatsItem>
+              <Styled.CourseStatsItem>
+                <span style={{ color: "#A4A4A4" }}>고도</span> {totalElevation}
+              </Styled.CourseStatsItem>
+            </Styled.CourseStats>
+          </Styled.CourseMeta>
+        </Styled.Wrapper>
+      )}
     </>
   );
 };

--- a/src/components/course/courseInfo/CourseReview.tsx
+++ b/src/components/course/courseInfo/CourseReview.tsx
@@ -39,7 +39,7 @@ const CourseReview = () => {
       ) : courseReview.length > 0 ? (
         <CardList items={courseReview} type={type} onTypeChange={setType} />
       ) : (
-        <NoneData>{"아직 산의 리뷰가 없습니다."}</NoneData>
+        <NoneData>{"아직 코스의 리뷰가 없습니다."}</NoneData>
       )}
     </>
   );

--- a/src/components/course/courseInfo/CourseReview.tsx
+++ b/src/components/course/courseInfo/CourseReview.tsx
@@ -1,38 +1,59 @@
 import { CardList } from "../../common/card/CardList";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { courseReviewApi, CourseReviewItem } from "../../../apis/course/courseInfo/CourseReviewApi";
+import Skeleton from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+import styled from "styled-components";
 
 const CourseReview = () => {
-  const dummyCourseReview = [
-    {
-      id: 1,
-      title: "나들이로 딱 !",
-      level: "중",
-      description: "쉬운 난이도였지만 운동 안해서 등산이라 힘들었다",
-      imgUrl: "https://picsum.photos/200/300",
-      isLiked: false,
-    },
-    {
-      id: 2,
-      title: "나들이로 딱 !",
-      level: "하",
-      description: "아주아주 쉬웠어 최고 짱짱이야 ~~ 추천 합니다",
-      imgUrl: "",
-      isLiked: true,
-    },
-    {
-      id: 3,
-      title: "나들이로 딱 !",
-      level: "상",
-      description: "쉬운 난이도였지만 운동 안해서 등산이라 힘들었다",
-      imgUrl: "",
-      isLiked: true,
-    },
-  ];
+  const [courseReview, setCourseReview] = useState<CourseReviewItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [type, setType] = useState("최신순");
+
+  const { course_id } = useParams();
+  const id = parseInt(course_id ?? "", 10);
+
+  useEffect(() => {
+    if (isNaN(id)) return;
+
+    const fetchMntReview = async () => {
+      try {
+        setIsLoading(true);
+        const data = await courseReviewApi.getCourseReview(id, type);
+        setCourseReview(data);
+      } catch (error) {
+        console.error("코스 리뷰 가져오기 실패:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMntReview();
+  }, [id, type]);
 
   return (
     <>
-      <CardList items={dummyCourseReview} />
+      {isLoading ? (
+        <Skeleton width={"100%"} height={"100%"} />
+      ) : courseReview.length > 0 ? (
+        <CardList items={courseReview} type={type} onTypeChange={setType} />
+      ) : (
+        <NoneData>{"아직 산의 리뷰가 없습니다."}</NoneData>
+      )}
     </>
   );
 };
 
 export default CourseReview;
+
+const NoneData = styled.div`
+  width: 21.875rem;
+  height: 26rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #3b3b3b;
+`;

--- a/src/components/course/courseInfo/CourseReview.tsx
+++ b/src/components/course/courseInfo/CourseReview.tsx
@@ -48,7 +48,7 @@ const CourseReview = () => {
 export default CourseReview;
 
 const NoneData = styled.div`
-  width: 21.875rem;
+  width: 100%;
   height: 26rem;
   display: flex;
   align-items: center;

--- a/src/components/course/courseInfo/SketchMap.tsx
+++ b/src/components/course/courseInfo/SketchMap.tsx
@@ -1,19 +1,124 @@
 import * as Styled from "./SketchMap.styled";
 import useNaverMap from "../../../hooks/useNaverMap";
 import { Section } from "../../../types/naverMap";
+import course_ids from "../../../data/course_ids.json"; // 1. course_ids, MountainData import 해주기
+import { MountainData } from "../../../types/mountainData";
+import Skeleton from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+import { useState, useEffect, useMemo } from "react";
+import { useParams } from "react-router-dom";
 
-interface Props {
-  sections: Section[];
-}
+const SketchMap = () => {
+  const [courseData, setCourseData] = useState<MountainData | null>(null); // 2. 여기에도 MountainData useState로 설정해줘야 돼요
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mapInitialized, setMapInitialized] = useState(false);
 
-const SketchMap = ({ sections }: Props) => {
-  const { mapRef } = useNaverMap({ sections });
+  // 3. 여기서부터 course_id로 course_ids.json에서 코스 데이터 경로 가져오기 시작
+  const { course_id } = useParams();
+  const id = parseInt(course_id ?? "", 10);
+
+  useEffect(() => {
+    const loadMountainData = async () => {
+      try {
+        setLoading(true);
+
+        // 3-1) course_ids에서 코스 데이터 경로 찾기
+        const mnt_course = course_ids.find((item) => Number(item.course_id) === id);
+
+        // 유효한 코스를 찾았는지 확인
+        if (!mnt_course?.courseFilePath) {
+          setError("코스 정보를 찾을 수 없습니다.");
+          setLoading(false);
+          return;
+        }
+
+        // console.log("Found course path:", mnt_course.courseFilePath);
+
+        // 3-2-1) 직접적인 동적 import 방식
+        try {
+          const dataModule = await import(`../../../data/mnt/${mnt_course.courseFilePath}`);
+          setCourseData(dataModule.default);
+          setLoading(false);
+        } catch (importError) {
+          console.error("파일 불러오기 실패:", importError);
+
+          // 3-2-1) 대체 방법: glob 방식 사용
+          const modules: Record<string, { default: MountainData }> = import.meta.glob("../../../data/mnt/**/*.json", {
+            eager: true,
+          });
+          // console.log("Available modules:", Object.keys(modules));
+
+          // 3-3) 코스.json 경로지정해서 불러오기
+          const targetPath = `../../../data/mnt/${mnt_course.courseFilePath}`;
+          const data = modules[targetPath];
+
+          if (data) {
+            setCourseData(data.default);
+            setLoading(false);
+          } else {
+            setError(`코스 데이터를 찾을 수 없습니다: ${mnt_course.courseFilePath}`);
+            setLoading(false);
+          }
+        }
+      } catch (err) {
+        console.error("데이터 로딩 오류:", err);
+        setError("코스 데이터를 불러오는 중 오류가 발생했습니다.");
+        setLoading(false);
+      }
+    };
+
+    loadMountainData();
+  }, [id]);
+
+  // ++ SketchMap에서 useNaverMap을 사용하기 위한 설정 ---
+  // 코스 데이터에서 sections 구성하기 (네이버 지도에 표시할 트랙)
+  const sections = useMemo<Section[]>(() => {
+    if (!courseData || !courseData.track) return [];
+
+    // courseData.track을 네이버 지도 API에 맞는 Section 형태로 변환
+    return courseData.track.map((segment) => ({
+      path: segment.path,
+      color: segment.color || "#3f611f", // 기본 색상 설정
+      start_name: segment.start_name,
+      end_name: segment.end_name,
+    }));
+  }, [courseData]);
+
+  // 네이버 지도 초기화
+  const { mapRef, isMapReady } = useNaverMap({
+    sections,
+    // 첫 번째 트랙의 첫 번째 좌표로 중심 설정 (없으면 기본값 사용)
+    initialCenter: sections[0]?.path[0] || undefined,
+    initialZoom: 12,
+  });
+
+  // 지도가 준비되면 초기화 상태 업데이트
+  useEffect(() => {
+    if (isMapReady && !mapInitialized) {
+      setMapInitialized(true);
+    }
+  }, [isMapReady, mapInitialized]);
+
+  // 4. courseData 불러오기 전에 return 될 내용 - 매번 되기 때문에 loading과 같은 스켈레톤으로 구상
+  if (loading || error || !courseData) {
+    return (
+      <Styled.SketchMapWrapper>
+        <Styled.CourseInfoTitle>약도</Styled.CourseInfoTitle>
+        <Styled.MapContainer>
+          <Skeleton height="100%" className="map-inner" />
+          {error && <div className="error-message">{error}</div>}
+        </Styled.MapContainer>
+      </Styled.SketchMapWrapper>
+    );
+  }
 
   return (
     <Styled.SketchMapWrapper>
       <Styled.CourseInfoTitle>약도</Styled.CourseInfoTitle>
       <Styled.MapContainer>
         <div ref={mapRef} className="map-inner" />
+        {!mapInitialized && <div className="loading-overlay">지도를 불러오는 중...</div>}
       </Styled.MapContainer>
     </Styled.SketchMapWrapper>
   );

--- a/src/components/course/courseList/MountainReview.tsx
+++ b/src/components/course/courseList/MountainReview.tsx
@@ -35,7 +35,7 @@ const CourseReview = () => {
   return (
     <>
       {isLoading ? (
-        <Skeleton width={"100%"} height={"11.100%"} />
+        <Skeleton width={"100%"} height={"100%"} />
       ) : mntReview.length > 0 ? (
         <CardList items={mntReview} type={type} onTypeChange={setType} />
       ) : (

--- a/src/data/course_ids.json
+++ b/src/data/course_ids.json
@@ -1,1312 +1,1574 @@
 [
-    {
-        "course_id": "1",
-        "mnt_id": "1",
-        "mnt_name": "가리산"
-    },
-    {
-        "course_id": "2",
-        "mnt_id": "2",
-        "mnt_name": "가리왕산"
-    },
-    {
-        "course_id": "3",
-        "mnt_id": "2",
-        "mnt_name": "가리왕산"
-    },
-    {
-        "course_id": "4",
-        "mnt_id": "3",
-        "mnt_name": "가야산"
-    },
-    {
-        "course_id": "5",
-        "mnt_id": "3",
-        "mnt_name": "가야산"
-    },
-    {
-        "course_id": "6",
-        "mnt_id": "3",
-        "mnt_name": "가야산"
-    },
-    {
-        "course_id": "7",
-        "mnt_id": "3",
-        "mnt_name": "가야산"
-    },
-    {
-        "course_id": "8",
-        "mnt_id": "3",
-        "mnt_name": "가야산"
-    },
-    {
-        "course_id": "9",
-        "mnt_id": "4",
-        "mnt_name": "가지산"
-    },
-    {
-        "course_id": "10",
-        "mnt_id": "4",
-        "mnt_name": "가지산"
-    },
-    {
-        "course_id": "11",
-        "mnt_id": "4",
-        "mnt_name": "가지산"
-    },
-    {
-        "course_id": "12",
-        "mnt_id": "4",
-        "mnt_name": "가지산"
-    },
-    {
-        "course_id": "13",
-        "mnt_id": "5",
-        "mnt_name": "감악산"
-    },
-    {
-        "course_id": "14",
-        "mnt_id": "5",
-        "mnt_name": "감악산"
-    },
-    {
-        "course_id": "15",
-        "mnt_id": "5",
-        "mnt_name": "감악산"
-    },
-    {
-        "course_id": "16",
-        "mnt_id": "6",
-        "mnt_name": "강천산"
-    },
-    {
-        "course_id": "17",
-        "mnt_id": "6",
-        "mnt_name": "강천산"
-    },
-    {
-        "course_id": "18",
-        "mnt_id": "7",
-        "mnt_name": "계룡산"
-    },
-    {
-        "course_id": "19",
-        "mnt_id": "7",
-        "mnt_name": "계룡산"
-    },
-    {
-        "course_id": "20",
-        "mnt_id": "7",
-        "mnt_name": "계룡산"
-    },
-    {
-        "course_id": "21",
-        "mnt_id": "7",
-        "mnt_name": "계룡산"
-    },
-    {
-        "course_id": "22",
-        "mnt_id": "8",
-        "mnt_name": "계방산"
-    },
-    {
-        "course_id": "23",
-        "mnt_id": "9",
-        "mnt_name": "공작산"
-    },
-    {
-        "course_id": "24",
-        "mnt_id": "9",
-        "mnt_name": "공작산"
-    },
-    {
-        "course_id": "25",
-        "mnt_id": "9",
-        "mnt_name": "공작산"
-    },
-    {
-        "course_id": "26",
-        "mnt_id": "10",
-        "mnt_name": "관악산"
-    },
-    {
-        "course_id": "27",
-        "mnt_id": "10",
-        "mnt_name": "관악산"
-    },
-    {
-        "course_id": "28",
-        "mnt_id": "11",
-        "mnt_name": "구병산"
-    },
-    {
-        "course_id": "29",
-        "mnt_id": "12",
-        "mnt_name": "금산"
-    },
-    {
-        "course_id": "30",
-        "mnt_id": "13",
-        "mnt_name": "금수산"
-    },
-    {
-        "course_id": "31",
-        "mnt_id": "13",
-        "mnt_name": "금수산"
-    },
-    {
-        "course_id": "32",
-        "mnt_id": "13",
-        "mnt_name": "금수산"
-    },
-    {
-        "course_id": "33",
-        "mnt_id": "13",
-        "mnt_name": "금수산"
-    },
-    {
-        "course_id": "34",
-        "mnt_id": "14",
-        "mnt_name": "금오산"
-    },
-    {
-        "course_id": "35",
-        "mnt_id": "14",
-        "mnt_name": "금오산"
-    },
-    {
-        "course_id": "36",
-        "mnt_id": "15",
-        "mnt_name": "금정산"
-    },
-    {
-        "course_id": "37",
-        "mnt_id": "15",
-        "mnt_name": "금정산"
-    },
-    {
-        "course_id": "38",
-        "mnt_id": "15",
-        "mnt_name": "금정산"
-    },
-    {
-        "course_id": "39",
-        "mnt_id": "16",
-        "mnt_name": "깃대봉"
-    },
-    {
-        "course_id": "40",
-        "mnt_id": "17",
-        "mnt_name": "남산"
-    },
-    {
-        "course_id": "41",
-        "mnt_id": "17",
-        "mnt_name": "남산"
-    },
-    {
-        "course_id": "42",
-        "mnt_id": "17",
-        "mnt_name": "남산"
-    },
-    {
-        "course_id": "43",
-        "mnt_id": "17",
-        "mnt_name": "남산"
-    },
-    {
-        "course_id": "44",
-        "mnt_id": "18",
-        "mnt_name": "내연산"
-    },
-    {
-        "course_id": "45",
-        "mnt_id": "18",
-        "mnt_name": "내연산"
-    },
-    {
-        "course_id": "46",
-        "mnt_id": "18",
-        "mnt_name": "내연산"
-    },
-    {
-        "course_id": "47",
-        "mnt_id": "18",
-        "mnt_name": "내연산"
-    },
-    {
-        "course_id": "48",
-        "mnt_id": "18",
-        "mnt_name": "내연산"
-    },
-    {
-        "course_id": "49",
-        "mnt_id": "19",
-        "mnt_name": "내장산"
-    },
-    {
-        "course_id": "50",
-        "mnt_id": "19",
-        "mnt_name": "내장산"
-    },
-    {
-        "course_id": "51",
-        "mnt_id": "19",
-        "mnt_name": "내장산"
-    },
-    {
-        "course_id": "52",
-        "mnt_id": "19",
-        "mnt_name": "내장산"
-    },
-    {
-        "course_id": "53",
-        "mnt_id": "20",
-        "mnt_name": "대둔산"
-    },
-    {
-        "course_id": "54",
-        "mnt_id": "21",
-        "mnt_name": "대야산"
-    },
-    {
-        "course_id": "55",
-        "mnt_id": "21",
-        "mnt_name": "대야산"
-    },
-    {
-        "course_id": "56",
-        "mnt_id": "21",
-        "mnt_name": "대야산"
-    },
-    {
-        "course_id": "57",
-        "mnt_id": "22",
-        "mnt_name": "덕숭산"
-    },
-    {
-        "course_id": "58",
-        "mnt_id": "23",
-        "mnt_name": "덕유산"
-    },
-    {
-        "course_id": "59",
-        "mnt_id": "23",
-        "mnt_name": "덕유산"
-    },
-    {
-        "course_id": "60",
-        "mnt_id": "23",
-        "mnt_name": "덕유산"
-    },
-    {
-        "course_id": "61",
-        "mnt_id": "24",
-        "mnt_name": "덕항산"
-    },
-    {
-        "course_id": "62",
-        "mnt_id": "24",
-        "mnt_name": "덕항산"
-    },
-    {
-        "course_id": "63",
-        "mnt_id": "25",
-        "mnt_name": "도락산"
-    },
-    {
-        "course_id": "64",
-        "mnt_id": "26",
-        "mnt_name": "도봉산"
-    },
-    {
-        "course_id": "65",
-        "mnt_id": "26",
-        "mnt_name": "도봉산"
-    },
-    {
-        "course_id": "66",
-        "mnt_id": "27",
-        "mnt_name": "두륜산"
-    },
-    {
-        "course_id": "67",
-        "mnt_id": "27",
-        "mnt_name": "두륜산"
-    },
-    {
-        "course_id": "68",
-        "mnt_id": "27",
-        "mnt_name": "두륜산"
-    },
-    {
-        "course_id": "69",
-        "mnt_id": "27",
-        "mnt_name": "두륜산"
-    },
-    {
-        "course_id": "70",
-        "mnt_id": "28",
-        "mnt_name": "두타산"
-    },
-    {
-        "course_id": "71",
-        "mnt_id": "28",
-        "mnt_name": "두타산"
-    },
-    {
-        "course_id": "72",
-        "mnt_id": "28",
-        "mnt_name": "두타산"
-    },
-    {
-        "course_id": "73",
-        "mnt_id": "29",
-        "mnt_name": "마니산"
-    },
-    {
-        "course_id": "74",
-        "mnt_id": "29",
-        "mnt_name": "마니산"
-    },
-    {
-        "course_id": "75",
-        "mnt_id": "29",
-        "mnt_name": "마니산"
-    },
-    {
-        "course_id": "76",
-        "mnt_id": "30",
-        "mnt_name": "마이산"
-    },
-    {
-        "course_id": "77",
-        "mnt_id": "30",
-        "mnt_name": "마이산"
-    },
-    {
-        "course_id": "78",
-        "mnt_id": "30",
-        "mnt_name": "마이산"
-    },
-    {
-        "course_id": "79",
-        "mnt_id": "31",
-        "mnt_name": "명성산"
-    },
-    {
-        "course_id": "80",
-        "mnt_id": "32",
-        "mnt_name": "명지산"
-    },
-    {
-        "course_id": "81",
-        "mnt_id": "32",
-        "mnt_name": "명지산"
-    },
-    {
-        "course_id": "82",
-        "mnt_id": "32",
-        "mnt_name": "명지산"
-    },
-    {
-        "course_id": "83",
-        "mnt_id": "32",
-        "mnt_name": "명지산"
-    },
-    {
-        "course_id": "84",
-        "mnt_id": "33",
-        "mnt_name": "모악산"
-    },
-    {
-        "course_id": "85",
-        "mnt_id": "33",
-        "mnt_name": "모악산"
-    },
-    {
-        "course_id": "86",
-        "mnt_id": "33",
-        "mnt_name": "모악산"
-    },
-    {
-        "course_id": "87",
-        "mnt_id": "34",
-        "mnt_name": "무등산"
-    },
-    {
-        "course_id": "88",
-        "mnt_id": "34",
-        "mnt_name": "무등산"
-    },
-    {
-        "course_id": "89",
-        "mnt_id": "34",
-        "mnt_name": "무등산"
-    },
-    {
-        "course_id": "90",
-        "mnt_id": "35",
-        "mnt_name": "무학산"
-    },
-    {
-        "course_id": "91",
-        "mnt_id": "35",
-        "mnt_name": "무학산"
-    },
-    {
-        "course_id": "92",
-        "mnt_id": "35",
-        "mnt_name": "무학산"
-    },
-    {
-        "course_id": "93",
-        "mnt_id": "36",
-        "mnt_name": "미륵산"
-    },
-    {
-        "course_id": "94",
-        "mnt_id": "36",
-        "mnt_name": "미륵산"
-    },
-    {
-        "course_id": "95",
-        "mnt_id": "36",
-        "mnt_name": "미륵산"
-    },
-    {
-        "course_id": "96",
-        "mnt_id": "37",
-        "mnt_name": "민주지산"
-    },
-    {
-        "course_id": "97",
-        "mnt_id": "38",
-        "mnt_name": "방장산"
-    },
-    {
-        "course_id": "98",
-        "mnt_id": "38",
-        "mnt_name": "방장산"
-    },
-    {
-        "course_id": "99",
-        "mnt_id": "39",
-        "mnt_name": "방태산"
-    },
-    {
-        "course_id": "100",
-        "mnt_id": "40",
-        "mnt_name": "백덕산"
-    },
-    {
-        "course_id": "101",
-        "mnt_id": "40",
-        "mnt_name": "백덕산"
-    },
-    {
-        "course_id": "102",
-        "mnt_id": "40",
-        "mnt_name": "백덕산"
-    },
-    {
-        "course_id": "103",
-        "mnt_id": "41",
-        "mnt_name": "백암산"
-    },
-    {
-        "course_id": "104",
-        "mnt_id": "41",
-        "mnt_name": "백암산"
-    },
-    {
-        "course_id": "105",
-        "mnt_id": "41",
-        "mnt_name": "백암산"
-    },
-    {
-        "course_id": "106",
-        "mnt_id": "41",
-        "mnt_name": "백암산"
-    },
-    {
-        "course_id": "107",
-        "mnt_id": "42",
-        "mnt_name": "백운산(광양)"
-    },
-    {
-        "course_id": "108",
-        "mnt_id": "42",
-        "mnt_name": "백운산(광양)"
-    },
-    {
-        "course_id": "109",
-        "mnt_id": "43",
-        "mnt_name": "백운산(정선)"
-    },
-    {
-        "course_id": "110",
-        "mnt_id": "43",
-        "mnt_name": "백운산(정선)"
-    },
-    {
-        "course_id": "111",
-        "mnt_id": "44",
-        "mnt_name": "백운산(포천)"
-    },
-    {
-        "course_id": "112",
-        "mnt_id": "44",
-        "mnt_name": "백운산(포천)"
-    },
-    {
-        "course_id": "113",
-        "mnt_id": "44",
-        "mnt_name": "백운산(포천)"
-    },
-    {
-        "course_id": "114",
-        "mnt_id": "45",
-        "mnt_name": "변산"
-    },
-    {
-        "course_id": "115",
-        "mnt_id": "45",
-        "mnt_name": "변산"
-    },
-    {
-        "course_id": "116",
-        "mnt_id": "45",
-        "mnt_name": "변산"
-    },
-    {
-        "course_id": "117",
-        "mnt_id": "45",
-        "mnt_name": "변산"
-    },
-    {
-        "course_id": "118",
-        "mnt_id": "45",
-        "mnt_name": "변산"
-    },
-    {
-        "course_id": "119",
-        "mnt_id": "46",
-        "mnt_name": "북한산"
-    },
-    {
-        "course_id": "120",
-        "mnt_id": "46",
-        "mnt_name": "북한산"
-    },
-    {
-        "course_id": "121",
-        "mnt_id": "46",
-        "mnt_name": "북한산"
-    },
-    {
-        "course_id": "122",
-        "mnt_id": "47",
-        "mnt_name": "비슬산"
-    },
-    {
-        "course_id": "123",
-        "mnt_id": "47",
-        "mnt_name": "비슬산"
-    },
-    {
-        "course_id": "124",
-        "mnt_id": "47",
-        "mnt_name": "비슬산"
-    },
-    {
-        "course_id": "125",
-        "mnt_id": "47",
-        "mnt_name": "비슬산"
-    },
-    {
-        "course_id": "126",
-        "mnt_id": "48",
-        "mnt_name": "삼악산"
-    },
-    {
-        "course_id": "127",
-        "mnt_id": "48",
-        "mnt_name": "삼악산"
-    },
-    {
-        "course_id": "128",
-        "mnt_id": "48",
-        "mnt_name": "삼악산"
-    },
-    {
-        "course_id": "129",
-        "mnt_id": "48",
-        "mnt_name": "삼악산"
-    },
-    {
-        "course_id": "130",
-        "mnt_id": "49",
-        "mnt_name": "서대산"
-    },
-    {
-        "course_id": "131",
-        "mnt_id": "49",
-        "mnt_name": "서대산"
-    },
-    {
-        "course_id": "132",
-        "mnt_id": "49",
-        "mnt_name": "서대산"
-    },
-    {
-        "course_id": "133",
-        "mnt_id": "49",
-        "mnt_name": "서대산"
-    },
-    {
-        "course_id": "134",
-        "mnt_id": "50",
-        "mnt_name": "선운산"
-    },
-    {
-        "course_id": "135",
-        "mnt_id": "50",
-        "mnt_name": "선운산"
-    },
-    {
-        "course_id": "136",
-        "mnt_id": "50",
-        "mnt_name": "선운산"
-    },
-    {
-        "course_id": "137",
-        "mnt_id": "50",
-        "mnt_name": "선운산"
-    },
-    {
-        "course_id": "138",
-        "mnt_id": "51",
-        "mnt_name": "설악산"
-    },
-    {
-        "course_id": "139",
-        "mnt_id": "51",
-        "mnt_name": "설악산"
-    },
-    {
-        "course_id": "140",
-        "mnt_id": "51",
-        "mnt_name": "설악산"
-    },
-    {
-        "course_id": "141",
-        "mnt_id": "51",
-        "mnt_name": "설악산"
-    },
-    {
-        "course_id": "142",
-        "mnt_id": "52",
-        "mnt_name": "성인봉"
-    },
-    {
-        "course_id": "143",
-        "mnt_id": "52",
-        "mnt_name": "성인봉"
-    },
-    {
-        "course_id": "144",
-        "mnt_id": "52",
-        "mnt_name": "성인봉"
-    },
-    {
-        "course_id": "145",
-        "mnt_id": "53",
-        "mnt_name": "소백산"
-    },
-    {
-        "course_id": "146",
-        "mnt_id": "53",
-        "mnt_name": "소백산"
-    },
-    {
-        "course_id": "147",
-        "mnt_id": "53",
-        "mnt_name": "소백산"
-    },
-    {
-        "course_id": "148",
-        "mnt_id": "54",
-        "mnt_name": "소요산"
-    },
-    {
-        "course_id": "149",
-        "mnt_id": "54",
-        "mnt_name": "소요산"
-    },
-    {
-        "course_id": "150",
-        "mnt_id": "54",
-        "mnt_name": "소요산"
-    },
-    {
-        "course_id": "151",
-        "mnt_id": "55",
-        "mnt_name": "속리산"
-    },
-    {
-        "course_id": "152",
-        "mnt_id": "55",
-        "mnt_name": "속리산"
-    },
-    {
-        "course_id": "153",
-        "mnt_id": "56",
-        "mnt_name": "신불산"
-    },
-    {
-        "course_id": "154",
-        "mnt_id": "56",
-        "mnt_name": "신불산"
-    },
-    {
-        "course_id": "155",
-        "mnt_id": "56",
-        "mnt_name": "신불산"
-    },
-    {
-        "course_id": "156",
-        "mnt_id": "56",
-        "mnt_name": "신불산"
-    },
-    {
-        "course_id": "157",
-        "mnt_id": "57",
-        "mnt_name": "연화산"
-    },
-    {
-        "course_id": "158",
-        "mnt_id": "57",
-        "mnt_name": "연화산"
-    },
-    {
-        "course_id": "159",
-        "mnt_id": "58",
-        "mnt_name": "오대산"
-    },
-    {
-        "course_id": "160",
-        "mnt_id": "58",
-        "mnt_name": "오대산"
-    },
-    {
-        "course_id": "161",
-        "mnt_id": "58",
-        "mnt_name": "오대산"
-    },
-    {
-        "course_id": "162",
-        "mnt_id": "58",
-        "mnt_name": "오대산"
-    },
-    {
-        "course_id": "163",
-        "mnt_id": "59",
-        "mnt_name": "오봉산"
-    },
-    {
-        "course_id": "164",
-        "mnt_id": "59",
-        "mnt_name": "오봉산"
-    },
-    {
-        "course_id": "165",
-        "mnt_id": "60",
-        "mnt_name": "용문산"
-    },
-    {
-        "course_id": "166",
-        "mnt_id": "60",
-        "mnt_name": "용문산"
-    },
-    {
-        "course_id": "167",
-        "mnt_id": "60",
-        "mnt_name": "용문산"
-    },
-    {
-        "course_id": "168",
-        "mnt_id": "60",
-        "mnt_name": "용문산"
-    },
-    {
-        "course_id": "169",
-        "mnt_id": "61",
-        "mnt_name": "용화산"
-    },
-    {
-        "course_id": "170",
-        "mnt_id": "61",
-        "mnt_name": "용화산"
-    },
-    {
-        "course_id": "171",
-        "mnt_id": "61",
-        "mnt_name": "용화산"
-    },
-    {
-        "course_id": "172",
-        "mnt_id": "62",
-        "mnt_name": "운문산"
-    },
-    {
-        "course_id": "173",
-        "mnt_id": "62",
-        "mnt_name": "운문산"
-    },
-    {
-        "course_id": "174",
-        "mnt_id": "63",
-        "mnt_name": "운악산"
-    },
-    {
-        "course_id": "175",
-        "mnt_id": "63",
-        "mnt_name": "운악산"
-    },
-    {
-        "course_id": "176",
-        "mnt_id": "63",
-        "mnt_name": "운악산"
-    },
-    {
-        "course_id": "177",
-        "mnt_id": "64",
-        "mnt_name": "운장산"
-    },
-    {
-        "course_id": "178",
-        "mnt_id": "65",
-        "mnt_name": "월악산"
-    },
-    {
-        "course_id": "179",
-        "mnt_id": "65",
-        "mnt_name": "월악산"
-    },
-    {
-        "course_id": "180",
-        "mnt_id": "65",
-        "mnt_name": "월악산"
-    },
-    {
-        "course_id": "181",
-        "mnt_id": "66",
-        "mnt_name": "월출산"
-    },
-    {
-        "course_id": "182",
-        "mnt_id": "66",
-        "mnt_name": "월출산"
-    },
-    {
-        "course_id": "183",
-        "mnt_id": "66",
-        "mnt_name": "월출산"
-    },
-    {
-        "course_id": "184",
-        "mnt_id": "66",
-        "mnt_name": "월출산"
-    },
-    {
-        "course_id": "185",
-        "mnt_id": "66",
-        "mnt_name": "월출산"
-    },
-    {
-        "course_id": "186",
-        "mnt_id": "67",
-        "mnt_name": "유명산"
-    },
-    {
-        "course_id": "187",
-        "mnt_id": "67",
-        "mnt_name": "유명산"
-    },
-    {
-        "course_id": "188",
-        "mnt_id": "67",
-        "mnt_name": "유명산"
-    },
-    {
-        "course_id": "189",
-        "mnt_id": "68",
-        "mnt_name": "응봉산"
-    },
-    {
-        "course_id": "190",
-        "mnt_id": "69",
-        "mnt_name": "장안산"
-    },
-    {
-        "course_id": "191",
-        "mnt_id": "70",
-        "mnt_name": "재약산"
-    },
-    {
-        "course_id": "192",
-        "mnt_id": "71",
-        "mnt_name": "적상산"
-    },
-    {
-        "course_id": "193",
-        "mnt_id": "72",
-        "mnt_name": "점봉산"
-    },
-    {
-        "course_id": "194",
-        "mnt_id": "73",
-        "mnt_name": "조계산"
-    },
-    {
-        "course_id": "195",
-        "mnt_id": "73",
-        "mnt_name": "조계산"
-    },
-    {
-        "course_id": "196",
-        "mnt_id": "74",
-        "mnt_name": "주왕산"
-    },
-    {
-        "course_id": "197",
-        "mnt_id": "75",
-        "mnt_name": "주흘산"
-    },
-    {
-        "course_id": "198",
-        "mnt_id": "76",
-        "mnt_name": "지리산(천왕봉)"
-    },
-    {
-        "course_id": "199",
-        "mnt_id": "76",
-        "mnt_name": "지리산(천왕봉)"
-    },
-    {
-        "course_id": "200",
-        "mnt_id": "76",
-        "mnt_name": "지리산(천왕봉)"
-    },
-    {
-        "course_id": "201",
-        "mnt_id": "77",
-        "mnt_name": "지리산(통영)"
-    },
-    {
-        "course_id": "202",
-        "mnt_id": "78",
-        "mnt_name": "천관산"
-    },
-    {
-        "course_id": "203",
-        "mnt_id": "78",
-        "mnt_name": "천관산"
-    },
-    {
-        "course_id": "204",
-        "mnt_id": "78",
-        "mnt_name": "천관산"
-    },
-    {
-        "course_id": "205",
-        "mnt_id": "79",
-        "mnt_name": "천마산"
-    },
-    {
-        "course_id": "206",
-        "mnt_id": "79",
-        "mnt_name": "천마산"
-    },
-    {
-        "course_id": "207",
-        "mnt_id": "80",
-        "mnt_name": "천성산"
-    },
-    {
-        "course_id": "208",
-        "mnt_id": "81",
-        "mnt_name": "천태산"
-    },
-    {
-        "course_id": "209",
-        "mnt_id": "81",
-        "mnt_name": "천태산"
-    },
-    {
-        "course_id": "210",
-        "mnt_id": "82",
-        "mnt_name": "청량산"
-    },
-    {
-        "course_id": "211",
-        "mnt_id": "82",
-        "mnt_name": "청량산"
-    },
-    {
-        "course_id": "212",
-        "mnt_id": "82",
-        "mnt_name": "청량산"
-    },
-    {
-        "course_id": "213",
-        "mnt_id": "83",
-        "mnt_name": "추월산"
-    },
-    {
-        "course_id": "214",
-        "mnt_id": "83",
-        "mnt_name": "추월산"
-    },
-    {
-        "course_id": "215",
-        "mnt_id": "84",
-        "mnt_name": "축령산"
-    },
-    {
-        "course_id": "216",
-        "mnt_id": "84",
-        "mnt_name": "축령산"
-    },
-    {
-        "course_id": "217",
-        "mnt_id": "84",
-        "mnt_name": "축령산"
-    },
-    {
-        "course_id": "218",
-        "mnt_id": "85",
-        "mnt_name": "치악산"
-    },
-    {
-        "course_id": "219",
-        "mnt_id": "85",
-        "mnt_name": "치악산"
-    },
-    {
-        "course_id": "220",
-        "mnt_id": "85",
-        "mnt_name": "치악산"
-    },
-    {
-        "course_id": "221",
-        "mnt_id": "86",
-        "mnt_name": "칠갑산"
-    },
-    {
-        "course_id": "222",
-        "mnt_id": "86",
-        "mnt_name": "칠갑산"
-    },
-    {
-        "course_id": "223",
-        "mnt_id": "86",
-        "mnt_name": "칠갑산"
-    },
-    {
-        "course_id": "224",
-        "mnt_id": "86",
-        "mnt_name": "칠갑산"
-    },
-    {
-        "course_id": "225",
-        "mnt_id": "87",
-        "mnt_name": "태백산"
-    },
-    {
-        "course_id": "226",
-        "mnt_id": "87",
-        "mnt_name": "태백산"
-    },
-    {
-        "course_id": "227",
-        "mnt_id": "87",
-        "mnt_name": "태백산"
-    },
-    {
-        "course_id": "228",
-        "mnt_id": "87",
-        "mnt_name": "태백산"
-    },
-    {
-        "course_id": "229",
-        "mnt_id": "88",
-        "mnt_name": "태화산"
-    },
-    {
-        "course_id": "230",
-        "mnt_id": "88",
-        "mnt_name": "태화산"
-    },
-    {
-        "course_id": "231",
-        "mnt_id": "89",
-        "mnt_name": "팔공산"
-    },
-    {
-        "course_id": "232",
-        "mnt_id": "89",
-        "mnt_name": "팔공산"
-    },
-    {
-        "course_id": "233",
-        "mnt_id": "90",
-        "mnt_name": "팔봉산"
-    },
-    {
-        "course_id": "234",
-        "mnt_id": "91",
-        "mnt_name": "팔영산"
-    },
-    {
-        "course_id": "235",
-        "mnt_id": "91",
-        "mnt_name": "팔영산"
-    },
-    {
-        "course_id": "236",
-        "mnt_id": "92",
-        "mnt_name": "한라산"
-    },
-    {
-        "course_id": "237",
-        "mnt_id": "92",
-        "mnt_name": "한라산"
-    },
-    {
-        "course_id": "238",
-        "mnt_id": "92",
-        "mnt_name": "한라산"
-    },
-    {
-        "course_id": "239",
-        "mnt_id": "92",
-        "mnt_name": "한라산"
-    },
-    {
-        "course_id": "240",
-        "mnt_id": "92",
-        "mnt_name": "한라산"
-    },
-    {
-        "course_id": "241",
-        "mnt_id": "93",
-        "mnt_name": "화악산"
-    },
-    {
-        "course_id": "242",
-        "mnt_id": "93",
-        "mnt_name": "화악산"
-    },
-    {
-        "course_id": "243",
-        "mnt_id": "93",
-        "mnt_name": "화악산"
-    },
-    {
-        "course_id": "244",
-        "mnt_id": "93",
-        "mnt_name": "화악산"
-    },
-    {
-        "course_id": "245",
-        "mnt_id": "94",
-        "mnt_name": "화왕산"
-    },
-    {
-        "course_id": "246",
-        "mnt_id": "94",
-        "mnt_name": "화왕산"
-    },
-    {
-        "course_id": "247",
-        "mnt_id": "94",
-        "mnt_name": "화왕산"
-    },
-    {
-        "course_id": "248",
-        "mnt_id": "94",
-        "mnt_name": "화왕산"
-    },
-    {
-        "course_id": "249",
-        "mnt_id": "94",
-        "mnt_name": "화왕산"
-    },
-    {
-        "course_id": "250",
-        "mnt_id": "95",
-        "mnt_name": "황매산"
-    },
-    {
-        "course_id": "251",
-        "mnt_id": "95",
-        "mnt_name": "황매산"
-    },
-    {
-        "course_id": "252",
-        "mnt_id": "95",
-        "mnt_name": "황매산"
-    },
-    {
-        "course_id": "253",
-        "mnt_id": "95",
-        "mnt_name": "황매산"
-    },
-    {
-        "course_id": "254",
-        "mnt_id": "96",
-        "mnt_name": "황석산"
-    },
-    {
-        "course_id": "255",
-        "mnt_id": "96",
-        "mnt_name": "황석산"
-    },
-    {
-        "course_id": "256",
-        "mnt_id": "97",
-        "mnt_name": "황악산"
-    },
-    {
-        "course_id": "257",
-        "mnt_id": "97",
-        "mnt_name": "황악산"
-    },
-    {
-        "course_id": "258",
-        "mnt_id": "98",
-        "mnt_name": "황장산"
-    },
-    {
-        "course_id": "259",
-        "mnt_id": "99",
-        "mnt_name": "희양산"
-    },
-    {
-        "course_id": "260",
-        "mnt_id": "99",
-        "mnt_name": "희양산"
-    },
-    {
-        "course_id": "261",
-        "mnt_id": "99",
-        "mnt_name": "희양산"
-    },
-    {
-        "course_id": "262",
-        "mnt_id": "1",
-        "mnt_name": "가리산"
-    }
+  {
+    "course_id": "178",
+    "mnt_id": "65",
+    "courseFilePath": "월악산/월악산_4.json",
+    "mnt_name": "월악산"
+  },
+  {
+    "course_id": "179",
+    "mnt_id": "65",
+    "courseFilePath": "월악산/월악산_2.json",
+    "mnt_name": "월악산"
+  },
+  {
+    "course_id": "180",
+    "mnt_id": "65",
+    "courseFilePath": "월악산/월악산_1.json",
+    "mnt_name": "월악산"
+  },
+  {
+    "course_id": "134",
+    "mnt_id": "50",
+    "courseFilePath": "선운산/선운산_3.json",
+    "mnt_name": "선운산"
+  },
+  {
+    "course_id": "135",
+    "mnt_id": "50",
+    "courseFilePath": "선운산/선운산_2.json",
+    "mnt_name": "선운산"
+  },
+  {
+    "course_id": "136",
+    "mnt_id": "50",
+    "courseFilePath": "선운산/선운산_5.json",
+    "mnt_name": "선운산"
+  },
+  {
+    "course_id": "137",
+    "mnt_id": "50",
+    "courseFilePath": "선운산/선운산_1.json",
+    "mnt_name": "선운산"
+  },
+  {
+    "course_id": "13",
+    "mnt_id": "5",
+    "courseFilePath": "감악산/감악산_2.json",
+    "mnt_name": "감악산"
+  },
+  {
+    "course_id": "14",
+    "mnt_id": "5",
+    "courseFilePath": "감악산/감악산_3.json",
+    "mnt_name": "감악산"
+  },
+  {
+    "course_id": "15",
+    "mnt_id": "5",
+    "courseFilePath": "감악산/감악산_1.json",
+    "mnt_name": "감악산"
+  },
+  {
+    "course_id": "79",
+    "mnt_id": "31",
+    "courseFilePath": "명성산/명성산_1.json",
+    "mnt_name": "명성산"
+  },
+  {
+    "course_id": "229",
+    "mnt_id": "88",
+    "courseFilePath": "태화산/태화산_3.json",
+    "mnt_name": "태화산"
+  },
+  {
+    "course_id": "230",
+    "mnt_id": "88",
+    "courseFilePath": "태화산/태화산_1.json",
+    "mnt_name": "태화산"
+  },
+  {
+    "course_id": "126",
+    "mnt_id": "48",
+    "courseFilePath": "삼악산/삼악산_4.json",
+    "mnt_name": "삼악산"
+  },
+  {
+    "course_id": "127",
+    "mnt_id": "48",
+    "courseFilePath": "삼악산/삼악산_3.json",
+    "mnt_name": "삼악산"
+  },
+  {
+    "course_id": "128",
+    "mnt_id": "48",
+    "courseFilePath": "삼악산/삼악산_2.json",
+    "mnt_name": "삼악산"
+  },
+  {
+    "course_id": "129",
+    "mnt_id": "48",
+    "courseFilePath": "삼악산/삼악산_1.json",
+    "mnt_name": "삼악산"
+  },
+  {
+    "course_id": "191",
+    "mnt_id": "70",
+    "courseFilePath": "재약산/재약산_2.json",
+    "mnt_name": "재약산"
+  },
+  {
+    "course_id": "163",
+    "mnt_id": "59",
+    "courseFilePath": "오봉산/오봉산_2.json",
+    "mnt_name": "오봉산"
+  },
+  {
+    "course_id": "164",
+    "mnt_id": "59",
+    "courseFilePath": "오봉산/오봉산_1.json",
+    "mnt_name": "오봉산"
+  },
+  {
+    "course_id": "234",
+    "mnt_id": "91",
+    "courseFilePath": "팔영산/팔영산_2.json",
+    "mnt_name": "팔영산"
+  },
+  {
+    "course_id": "235",
+    "mnt_id": "91",
+    "courseFilePath": "팔영산/팔영산_1.json",
+    "mnt_name": "팔영산"
+  },
+  {
+    "course_id": "221",
+    "mnt_id": "86",
+    "courseFilePath": "칠갑산/칠갑산_1.json",
+    "mnt_name": "칠갑산"
+  },
+  {
+    "course_id": "222",
+    "mnt_id": "86",
+    "courseFilePath": "칠갑산/칠갑산_3.json",
+    "mnt_name": "칠갑산"
+  },
+  {
+    "course_id": "223",
+    "mnt_id": "86",
+    "courseFilePath": "칠갑산/칠갑산_2.json",
+    "mnt_name": "칠갑산"
+  },
+  {
+    "course_id": "224",
+    "mnt_id": "86",
+    "courseFilePath": "칠갑산/칠갑산_4.json",
+    "mnt_name": "칠갑산"
+  },
+  {
+    "course_id": "53",
+    "mnt_id": "20",
+    "courseFilePath": "대둔산/대둔산_1.json",
+    "mnt_name": "대둔산"
+  },
+  {
+    "course_id": "151",
+    "mnt_id": "55",
+    "courseFilePath": "속리산/속리산_1.json",
+    "mnt_name": "속리산"
+  },
+  {
+    "course_id": "152",
+    "mnt_id": "55",
+    "courseFilePath": "속리산/속리산_3.json",
+    "mnt_name": "속리산"
+  },
+  {
+    "course_id": "197",
+    "mnt_id": "75",
+    "courseFilePath": "주흘산/주흘산_3.json",
+    "mnt_name": "주흘산"
+  },
+  {
+    "course_id": "4",
+    "mnt_id": "3",
+    "courseFilePath": "가야산/가야산_2.json",
+    "mnt_name": "가야산"
+  },
+  {
+    "course_id": "5",
+    "mnt_id": "3",
+    "courseFilePath": "가야산/가야산_3.json",
+    "mnt_name": "가야산"
+  },
+  {
+    "course_id": "6",
+    "mnt_id": "3",
+    "courseFilePath": "가야산/가야산_4.json",
+    "mnt_name": "가야산"
+  },
+  {
+    "course_id": "7",
+    "mnt_id": "3",
+    "courseFilePath": "가야산/가야산_5.json",
+    "mnt_name": "가야산"
+  },
+  {
+    "course_id": "8",
+    "mnt_id": "3",
+    "courseFilePath": "가야산/가야산_1.json",
+    "mnt_name": "가야산"
+  },
+  {
+    "course_id": "210",
+    "mnt_id": "82",
+    "courseFilePath": "청량산/청량산_1.json",
+    "mnt_name": "청량산"
+  },
+  {
+    "course_id": "211",
+    "mnt_id": "82",
+    "courseFilePath": "청량산/청량산_2.json",
+    "mnt_name": "청량산"
+  },
+  {
+    "course_id": "212",
+    "mnt_id": "82",
+    "courseFilePath": "청량산/청량산_3.json",
+    "mnt_name": "청량산"
+  },
+  {
+    "course_id": "254",
+    "mnt_id": "96",
+    "courseFilePath": "황석산/황석산_2.json",
+    "mnt_name": "황석산"
+  },
+  {
+    "course_id": "255",
+    "mnt_id": "96",
+    "courseFilePath": "황석산/황석산_6.json",
+    "mnt_name": "황석산"
+  },
+  {
+    "course_id": "122",
+    "mnt_id": "47",
+    "courseFilePath": "비슬산/비슬산_5.json",
+    "mnt_name": "비슬산"
+  },
+  {
+    "course_id": "123",
+    "mnt_id": "47",
+    "courseFilePath": "비슬산/비슬산_4.json",
+    "mnt_name": "비슬산"
+  },
+  {
+    "course_id": "124",
+    "mnt_id": "47",
+    "courseFilePath": "비슬산/비슬산_3.json",
+    "mnt_name": "비슬산"
+  },
+  {
+    "course_id": "125",
+    "mnt_id": "47",
+    "courseFilePath": "비슬산/비슬산_2.json",
+    "mnt_name": "비슬산"
+  },
+  {
+    "course_id": "236",
+    "mnt_id": "92",
+    "courseFilePath": "한라산/한라산_5.json",
+    "mnt_name": "한라산"
+  },
+  {
+    "course_id": "237",
+    "mnt_id": "92",
+    "courseFilePath": "한라산/한라산_4.json",
+    "mnt_name": "한라산"
+  },
+  {
+    "course_id": "238",
+    "mnt_id": "92",
+    "courseFilePath": "한라산/한라산_3.json",
+    "mnt_name": "한라산"
+  },
+  {
+    "course_id": "239",
+    "mnt_id": "92",
+    "courseFilePath": "한라산/한라산_2.json",
+    "mnt_name": "한라산"
+  },
+  {
+    "course_id": "240",
+    "mnt_id": "92",
+    "courseFilePath": "한라산/한라산_1.json",
+    "mnt_name": "한라산"
+  },
+  {
+    "course_id": "258",
+    "mnt_id": "98",
+    "courseFilePath": "황장산/황장산_1.json",
+    "mnt_name": "황장산"
+  },
+  {
+    "course_id": "34",
+    "mnt_id": "14",
+    "courseFilePath": "금오산/금오산_5.json",
+    "mnt_name": "금오산"
+  },
+  {
+    "course_id": "35",
+    "mnt_id": "14",
+    "courseFilePath": "금오산/금오산_2.json",
+    "mnt_name": "금오산"
+  },
+  {
+    "course_id": "138",
+    "mnt_id": "51",
+    "courseFilePath": "설악산/설악산_4.json",
+    "mnt_name": "설악산"
+  },
+  {
+    "course_id": "139",
+    "mnt_id": "51",
+    "courseFilePath": "설악산/설악산_2.json",
+    "mnt_name": "설악산"
+  },
+  {
+    "course_id": "140",
+    "mnt_id": "51",
+    "courseFilePath": "설악산/설악산_1.json",
+    "mnt_name": "설악산"
+  },
+  {
+    "course_id": "141",
+    "mnt_id": "51",
+    "courseFilePath": "설악산/설악산_6.json",
+    "mnt_name": "설악산"
+  },
+  {
+    "course_id": "114",
+    "mnt_id": "45",
+    "courseFilePath": "변산/변산_1.json",
+    "mnt_name": "변산"
+  },
+  {
+    "course_id": "115",
+    "mnt_id": "45",
+    "courseFilePath": "변산/변산_2.json",
+    "mnt_name": "변산"
+  },
+  {
+    "course_id": "116",
+    "mnt_id": "45",
+    "courseFilePath": "변산/변산_3.json",
+    "mnt_name": "변산"
+  },
+  {
+    "course_id": "117",
+    "mnt_id": "45",
+    "courseFilePath": "변산/변산_4.json",
+    "mnt_name": "변산"
+  },
+  {
+    "course_id": "118",
+    "mnt_id": "45",
+    "courseFilePath": "변산/변산_5.json",
+    "mnt_name": "변산"
+  },
+  {
+    "course_id": "177",
+    "mnt_id": "64",
+    "courseFilePath": "운장산/운장산_1.json",
+    "mnt_name": "운장산"
+  },
+  {
+    "course_id": "22",
+    "mnt_id": "8",
+    "courseFilePath": "계방산/계방산_2.json",
+    "mnt_name": "계방산"
+  },
+  {
+    "course_id": "28",
+    "mnt_id": "11",
+    "courseFilePath": "구병산/구병산_1.json",
+    "mnt_name": "구병산"
+  },
+  {
+    "course_id": "93",
+    "mnt_id": "36",
+    "courseFilePath": "미륵산/미륵산_1.json",
+    "mnt_name": "미륵산"
+  },
+  {
+    "course_id": "94",
+    "mnt_id": "36",
+    "courseFilePath": "미륵산/미륵산_4.json",
+    "mnt_name": "미륵산"
+  },
+  {
+    "course_id": "95",
+    "mnt_id": "36",
+    "courseFilePath": "미륵산/미륵산_3.json",
+    "mnt_name": "미륵산"
+  },
+  {
+    "course_id": "66",
+    "mnt_id": "27",
+    "courseFilePath": "두륜산/두륜산_1.json",
+    "mnt_name": "두륜산"
+  },
+  {
+    "course_id": "67",
+    "mnt_id": "27",
+    "courseFilePath": "두륜산/두륜산_2.json",
+    "mnt_name": "두륜산"
+  },
+  {
+    "course_id": "68",
+    "mnt_id": "27",
+    "courseFilePath": "두륜산/두륜산_3.json",
+    "mnt_name": "두륜산"
+  },
+  {
+    "course_id": "69",
+    "mnt_id": "27",
+    "courseFilePath": "두륜산/두륜산_4.json",
+    "mnt_name": "두륜산"
+  },
+  {
+    "course_id": "9",
+    "mnt_id": "4",
+    "courseFilePath": "가지산/가지산_1.json",
+    "mnt_name": "가지산"
+  },
+  {
+    "course_id": "10",
+    "mnt_id": "4",
+    "courseFilePath": "가지산/가지산_3.json",
+    "mnt_name": "가지산"
+  },
+  {
+    "course_id": "11",
+    "mnt_id": "4",
+    "courseFilePath": "가지산/가지산_2.json",
+    "mnt_name": "가지산"
+  },
+  {
+    "course_id": "12",
+    "mnt_id": "4",
+    "courseFilePath": "가지산/가지산_4.json",
+    "mnt_name": "가지산"
+  },
+  {
+    "course_id": "76",
+    "mnt_id": "30",
+    "courseFilePath": "마이산/마이산_6.json",
+    "mnt_name": "마이산"
+  },
+  {
+    "course_id": "77",
+    "mnt_id": "30",
+    "courseFilePath": "마이산/마이산_5.json",
+    "mnt_name": "마이산"
+  },
+  {
+    "course_id": "78",
+    "mnt_id": "30",
+    "courseFilePath": "마이산/마이산_4.json",
+    "mnt_name": "마이산"
+  },
+  {
+    "course_id": "109",
+    "mnt_id": "43",
+    "courseFilePath": "백운산(정선)/백운산(정선)_1.json",
+    "mnt_name": "백운산(정선)"
+  },
+  {
+    "course_id": "110",
+    "mnt_id": "43",
+    "courseFilePath": "백운산(정선)/백운산(정선)_2.json",
+    "mnt_name": "백운산(정선)"
+  },
+  {
+    "course_id": "29",
+    "mnt_id": "12",
+    "courseFilePath": "금산/금산_1.json",
+    "mnt_name": "금산"
+  },
+  {
+    "course_id": "153",
+    "mnt_id": "56",
+    "courseFilePath": "신불산/신불산_4.json",
+    "mnt_name": "신불산"
+  },
+  {
+    "course_id": "154",
+    "mnt_id": "56",
+    "courseFilePath": "신불산/신불산_5.json",
+    "mnt_name": "신불산"
+  },
+  {
+    "course_id": "155",
+    "mnt_id": "56",
+    "courseFilePath": "신불산/신불산_2.json",
+    "mnt_name": "신불산"
+  },
+  {
+    "course_id": "156",
+    "mnt_id": "56",
+    "courseFilePath": "신불산/신불산_3.json",
+    "mnt_name": "신불산"
+  },
+  {
+    "course_id": "215",
+    "mnt_id": "84",
+    "courseFilePath": "축령산/축령산_1.json",
+    "mnt_name": "축령산"
+  },
+  {
+    "course_id": "216",
+    "mnt_id": "84",
+    "courseFilePath": "축령산/축령산_3.json",
+    "mnt_name": "축령산"
+  },
+  {
+    "course_id": "217",
+    "mnt_id": "84",
+    "courseFilePath": "축령산/축령산_4.json",
+    "mnt_name": "축령산"
+  },
+  {
+    "course_id": "225",
+    "mnt_id": "87",
+    "courseFilePath": "태백산/태백산_1.json",
+    "mnt_name": "태백산"
+  },
+  {
+    "course_id": "226",
+    "mnt_id": "87",
+    "courseFilePath": "태백산/태백산_5.json",
+    "mnt_name": "태백산"
+  },
+  {
+    "course_id": "227",
+    "mnt_id": "87",
+    "courseFilePath": "태백산/태백산_4.json",
+    "mnt_name": "태백산"
+  },
+  {
+    "course_id": "228",
+    "mnt_id": "87",
+    "courseFilePath": "태백산/태백산_3.json",
+    "mnt_name": "태백산"
+  },
+  {
+    "course_id": "259",
+    "mnt_id": "99",
+    "courseFilePath": "희양산/희양산_4.json",
+    "mnt_name": "희양산"
+  },
+  {
+    "course_id": "260",
+    "mnt_id": "99",
+    "courseFilePath": "희양산/희양산_2.json",
+    "mnt_name": "희양산"
+  },
+  {
+    "course_id": "261",
+    "mnt_id": "99",
+    "courseFilePath": "희양산/희양산_1.json",
+    "mnt_name": "희양산"
+  },
+  {
+    "course_id": "142",
+    "mnt_id": "52",
+    "courseFilePath": "성인봉/성인봉_4.json",
+    "mnt_name": "성인봉"
+  },
+  {
+    "course_id": "143",
+    "mnt_id": "52",
+    "courseFilePath": "성인봉/성인봉_2.json",
+    "mnt_name": "성인봉"
+  },
+  {
+    "course_id": "144",
+    "mnt_id": "52",
+    "courseFilePath": "성인봉/성인봉_3.json",
+    "mnt_name": "성인봉"
+  },
+  {
+    "course_id": "148",
+    "mnt_id": "54",
+    "courseFilePath": "소요산/소요산_1.json",
+    "mnt_name": "소요산"
+  },
+  {
+    "course_id": "149",
+    "mnt_id": "54",
+    "courseFilePath": "소요산/소요산_4.json",
+    "mnt_name": "소요산"
+  },
+  {
+    "course_id": "150",
+    "mnt_id": "54",
+    "courseFilePath": "소요산/소요산_2.json",
+    "mnt_name": "소요산"
+  },
+  {
+    "course_id": "205",
+    "mnt_id": "79",
+    "courseFilePath": "천마산/천마산_2.json",
+    "mnt_name": "천마산"
+  },
+  {
+    "course_id": "206",
+    "mnt_id": "79",
+    "courseFilePath": "천마산/천마산_5.json",
+    "mnt_name": "천마산"
+  },
+  {
+    "course_id": "201",
+    "mnt_id": "77",
+    "courseFilePath": "지리산(통영)/지리산(통영)_1.json",
+    "mnt_name": "지리산(통영)"
+  },
+  {
+    "course_id": "64",
+    "mnt_id": "26",
+    "courseFilePath": "도봉산/도봉산_7.json",
+    "mnt_name": "도봉산"
+  },
+  {
+    "course_id": "65",
+    "mnt_id": "26",
+    "courseFilePath": "도봉산/도봉산_6.json",
+    "mnt_name": "도봉산"
+  },
+  {
+    "course_id": "145",
+    "mnt_id": "53",
+    "courseFilePath": "소백산/소백산_4.json",
+    "mnt_name": "소백산"
+  },
+  {
+    "course_id": "146",
+    "mnt_id": "53",
+    "courseFilePath": "소백산/소백산_6.json",
+    "mnt_name": "소백산"
+  },
+  {
+    "course_id": "147",
+    "mnt_id": "53",
+    "courseFilePath": "소백산/소백산_1.json",
+    "mnt_name": "소백산"
+  },
+  {
+    "course_id": "18",
+    "mnt_id": "7",
+    "courseFilePath": "계룡산/계룡산_1.json",
+    "mnt_name": "계룡산"
+  },
+  {
+    "course_id": "19",
+    "mnt_id": "7",
+    "courseFilePath": "계룡산/계룡산_3.json",
+    "mnt_name": "계룡산"
+  },
+  {
+    "course_id": "20",
+    "mnt_id": "7",
+    "courseFilePath": "계룡산/계룡산_2.json",
+    "mnt_name": "계룡산"
+  },
+  {
+    "course_id": "21",
+    "mnt_id": "7",
+    "courseFilePath": "계룡산/계룡산_5.json",
+    "mnt_name": "계룡산"
+  },
+  {
+    "course_id": "23",
+    "mnt_id": "9",
+    "courseFilePath": "공작산/공작산_2.json",
+    "mnt_name": "공작산"
+  },
+  {
+    "course_id": "24",
+    "mnt_id": "9",
+    "courseFilePath": "공작산/공작산_3.json",
+    "mnt_name": "공작산"
+  },
+  {
+    "course_id": "25",
+    "mnt_id": "9",
+    "courseFilePath": "공작산/공작산_1.json",
+    "mnt_name": "공작산"
+  },
+  {
+    "course_id": "198",
+    "mnt_id": "76",
+    "courseFilePath": "지리산(천왕봉)/지리산_1.json",
+    "mnt_name": "지리산(천왕봉)"
+  },
+  {
+    "course_id": "199",
+    "mnt_id": "76",
+    "courseFilePath": "지리산(천왕봉)/지리산_2.json",
+    "mnt_name": "지리산(천왕봉)"
+  },
+  {
+    "course_id": "200",
+    "mnt_id": "76",
+    "courseFilePath": "지리산(천왕봉)/지리산_5.json",
+    "mnt_name": "지리산(천왕봉)"
+  },
+  {
+    "course_id": "36",
+    "mnt_id": "15",
+    "courseFilePath": "금정산/금정산_2.json",
+    "mnt_name": "금정산"
+  },
+  {
+    "course_id": "37",
+    "mnt_id": "15",
+    "courseFilePath": "금정산/금정산_3.json",
+    "mnt_name": "금정산"
+  },
+  {
+    "course_id": "38",
+    "mnt_id": "15",
+    "courseFilePath": "금정산/금정산_1.json",
+    "mnt_name": "금정산"
+  },
+  {
+    "course_id": "250",
+    "mnt_id": "95",
+    "courseFilePath": "황매산/황매산_1.json",
+    "mnt_name": "황매산"
+  },
+  {
+    "course_id": "251",
+    "mnt_id": "95",
+    "courseFilePath": "황매산/황매산_3.json",
+    "mnt_name": "황매산"
+  },
+  {
+    "course_id": "252",
+    "mnt_id": "95",
+    "courseFilePath": "황매산/황매산_2.json",
+    "mnt_name": "황매산"
+  },
+  {
+    "course_id": "253",
+    "mnt_id": "95",
+    "courseFilePath": "황매산/황매산_4.json",
+    "mnt_name": "황매산"
+  },
+  {
+    "course_id": "172",
+    "mnt_id": "62",
+    "courseFilePath": "운문산/운문산_3.json",
+    "mnt_name": "운문산"
+  },
+  {
+    "course_id": "173",
+    "mnt_id": "62",
+    "courseFilePath": "운문산/운문산_1.json",
+    "mnt_name": "운문산"
+  },
+  {
+    "course_id": "190",
+    "mnt_id": "69",
+    "courseFilePath": "장안산/장안산_1.json",
+    "mnt_name": "장안산"
+  },
+  {
+    "course_id": "0",
+    "mnt_id": "1",
+    "courseFilePath": "가리산/가리산_2.json",
+    "mnt_name": "가리산"
+  },
+  {
+    "course_id": "1",
+    "mnt_id": "1",
+    "courseFilePath": "가리산/가리산_1.json",
+    "mnt_name": "가리산"
+  },
+  {
+    "course_id": "111",
+    "mnt_id": "44",
+    "courseFilePath": "백운산(포천)/백운산(포천)_5.json",
+    "mnt_name": "백운산(포천)"
+  },
+  {
+    "course_id": "112",
+    "mnt_id": "44",
+    "courseFilePath": "백운산(포천)/백운산(포천)_2.json",
+    "mnt_name": "백운산(포천)"
+  },
+  {
+    "course_id": "113",
+    "mnt_id": "44",
+    "courseFilePath": "백운산(포천)/백운산(포천)_1.json",
+    "mnt_name": "백운산(포천)"
+  },
+  {
+    "course_id": "87",
+    "mnt_id": "34",
+    "courseFilePath": "무등산/무등산_2.json",
+    "mnt_name": "무등산"
+  },
+  {
+    "course_id": "88",
+    "mnt_id": "34",
+    "courseFilePath": "무등산/무등산_3.json",
+    "mnt_name": "무등산"
+  },
+  {
+    "course_id": "89",
+    "mnt_id": "34",
+    "courseFilePath": "무등산/무등산_1.json",
+    "mnt_name": "무등산"
+  },
+  {
+    "course_id": "99",
+    "mnt_id": "39",
+    "courseFilePath": "방태산/방태산_1.json",
+    "mnt_name": "방태산"
+  },
+  {
+    "course_id": "241",
+    "mnt_id": "93",
+    "courseFilePath": "화악산/화악산_5.json",
+    "mnt_name": "화악산"
+  },
+  {
+    "course_id": "242",
+    "mnt_id": "93",
+    "courseFilePath": "화악산/화악산_2.json",
+    "mnt_name": "화악산"
+  },
+  {
+    "course_id": "243",
+    "mnt_id": "93",
+    "courseFilePath": "화악산/화악산_1.json",
+    "mnt_name": "화악산"
+  },
+  {
+    "course_id": "244",
+    "mnt_id": "93",
+    "courseFilePath": "화악산/화악산_6.json",
+    "mnt_name": "화악산"
+  },
+  {
+    "course_id": "2",
+    "mnt_id": "2",
+    "courseFilePath": "가리왕산/가리왕산_2.json",
+    "mnt_name": "가리왕산"
+  },
+  {
+    "course_id": "3",
+    "mnt_id": "2",
+    "courseFilePath": "가리왕산/가리왕산_1.json",
+    "mnt_name": "가리왕산"
+  },
+  {
+    "course_id": "61",
+    "mnt_id": "24",
+    "courseFilePath": "덕항산/덕항산_2.json",
+    "mnt_name": "덕항산"
+  },
+  {
+    "course_id": "62",
+    "mnt_id": "24",
+    "courseFilePath": "덕항산/덕항산_1.json",
+    "mnt_name": "덕항산"
+  },
+  {
+    "course_id": "58",
+    "mnt_id": "23",
+    "courseFilePath": "덕유산/덕유산_3.json",
+    "mnt_name": "덕유산"
+  },
+  {
+    "course_id": "59",
+    "mnt_id": "23",
+    "courseFilePath": "덕유산/덕유산_4.json",
+    "mnt_name": "덕유산"
+  },
+  {
+    "course_id": "60",
+    "mnt_id": "23",
+    "courseFilePath": "덕유산/덕유산_1.json",
+    "mnt_name": "덕유산"
+  },
+  {
+    "course_id": "73",
+    "mnt_id": "29",
+    "courseFilePath": "마니산/마니산_3.json",
+    "mnt_name": "마니산"
+  },
+  {
+    "course_id": "74",
+    "mnt_id": "29",
+    "courseFilePath": "마니산/마니산_2.json",
+    "mnt_name": "마니산"
+  },
+  {
+    "course_id": "75",
+    "mnt_id": "29",
+    "courseFilePath": "마니산/마니산_1.json",
+    "mnt_name": "마니산"
+  },
+  {
+    "course_id": "208",
+    "mnt_id": "81",
+    "courseFilePath": "천태산/천태산_1.json",
+    "mnt_name": "천태산"
+  },
+  {
+    "course_id": "209",
+    "mnt_id": "81",
+    "courseFilePath": "천태산/천태산_2.json",
+    "mnt_name": "천태산"
+  },
+  {
+    "course_id": "54",
+    "mnt_id": "21",
+    "courseFilePath": "대야산/대야산_1.json",
+    "mnt_name": "대야산"
+  },
+  {
+    "course_id": "55",
+    "mnt_id": "21",
+    "courseFilePath": "대야산/대야산_3.json",
+    "mnt_name": "대야산"
+  },
+  {
+    "course_id": "56",
+    "mnt_id": "21",
+    "courseFilePath": "대야산/대야산_2.json",
+    "mnt_name": "대야산"
+  },
+  {
+    "course_id": "80",
+    "mnt_id": "32",
+    "courseFilePath": "명지산/명지산_1.json",
+    "mnt_name": "명지산"
+  },
+  {
+    "course_id": "81",
+    "mnt_id": "32",
+    "courseFilePath": "명지산/명지산_4.json",
+    "mnt_name": "명지산"
+  },
+  {
+    "course_id": "82",
+    "mnt_id": "32",
+    "courseFilePath": "명지산/명지산_2.json",
+    "mnt_name": "명지산"
+  },
+  {
+    "course_id": "83",
+    "mnt_id": "32",
+    "courseFilePath": "명지산/명지산_3.json",
+    "mnt_name": "명지산"
+  },
+  {
+    "course_id": "40",
+    "mnt_id": "17",
+    "courseFilePath": "남산/남산_1.json",
+    "mnt_name": "남산"
+  },
+  {
+    "course_id": "41",
+    "mnt_id": "17",
+    "courseFilePath": "남산/남산_4.json",
+    "mnt_name": "남산"
+  },
+  {
+    "course_id": "42",
+    "mnt_id": "17",
+    "courseFilePath": "남산/남산_5.json",
+    "mnt_name": "남산"
+  },
+  {
+    "course_id": "43",
+    "mnt_id": "17",
+    "courseFilePath": "남산/남산_3.json",
+    "mnt_name": "남산"
+  },
+  {
+    "course_id": "174",
+    "mnt_id": "63",
+    "courseFilePath": "운악산/운악산_2.json",
+    "mnt_name": "운악산"
+  },
+  {
+    "course_id": "175",
+    "mnt_id": "63",
+    "courseFilePath": "운악산/운악산_3.json",
+    "mnt_name": "운악산"
+  },
+  {
+    "course_id": "176",
+    "mnt_id": "63",
+    "courseFilePath": "운악산/운악산_1.json",
+    "mnt_name": "운악산"
+  },
+  {
+    "course_id": "57",
+    "mnt_id": "22",
+    "courseFilePath": "덕숭산/덕숭산_2.json",
+    "mnt_name": "덕숭산"
+  },
+  {
+    "course_id": "70",
+    "mnt_id": "28",
+    "courseFilePath": "두타산/두타산_3.json",
+    "mnt_name": "두타산"
+  },
+  {
+    "course_id": "71",
+    "mnt_id": "28",
+    "courseFilePath": "두타산/두타산_2.json",
+    "mnt_name": "두타산"
+  },
+  {
+    "course_id": "72",
+    "mnt_id": "28",
+    "courseFilePath": "두타산/두타산_1.json",
+    "mnt_name": "두타산"
+  },
+  {
+    "course_id": "196",
+    "mnt_id": "74",
+    "courseFilePath": "주왕산/주왕산_1.json",
+    "mnt_name": "주왕산"
+  },
+  {
+    "course_id": "231",
+    "mnt_id": "89",
+    "courseFilePath": "팔공산/팔공산_2.json",
+    "mnt_name": "팔공산"
+  },
+  {
+    "course_id": "232",
+    "mnt_id": "89",
+    "courseFilePath": "팔공산/팔공산_1.json",
+    "mnt_name": "팔공산"
+  },
+  {
+    "course_id": "100",
+    "mnt_id": "40",
+    "courseFilePath": "백덕산/백덕산_4.json",
+    "mnt_name": "백덕산"
+  },
+  {
+    "course_id": "101",
+    "mnt_id": "40",
+    "courseFilePath": "백덕산/백덕산_2.json",
+    "mnt_name": "백덕산"
+  },
+  {
+    "course_id": "102",
+    "mnt_id": "40",
+    "courseFilePath": "백덕산/백덕산_3.json",
+    "mnt_name": "백덕산"
+  },
+  {
+    "course_id": "181",
+    "mnt_id": "66",
+    "courseFilePath": "월출산/월출산_5.json",
+    "mnt_name": "월출산"
+  },
+  {
+    "course_id": "182",
+    "mnt_id": "66",
+    "courseFilePath": "월출산/월출산_4.json",
+    "mnt_name": "월출산"
+  },
+  {
+    "course_id": "183",
+    "mnt_id": "66",
+    "courseFilePath": "월출산/월출산_3.json",
+    "mnt_name": "월출산"
+  },
+  {
+    "course_id": "184",
+    "mnt_id": "66",
+    "courseFilePath": "월출산/월출산_2.json",
+    "mnt_name": "월출산"
+  },
+  {
+    "course_id": "185",
+    "mnt_id": "66",
+    "courseFilePath": "월출산/월출산_1.json",
+    "mnt_name": "월출산"
+  },
+  {
+    "course_id": "26",
+    "mnt_id": "10",
+    "courseFilePath": "관악산/관악산_2.json",
+    "mnt_name": "관악산"
+  },
+  {
+    "course_id": "27",
+    "mnt_id": "10",
+    "courseFilePath": "관악산/관악산_1.json",
+    "mnt_name": "관악산"
+  },
+  {
+    "course_id": "90",
+    "mnt_id": "35",
+    "courseFilePath": "무학산/무학산_2.json",
+    "mnt_name": "무학산"
+  },
+  {
+    "course_id": "91",
+    "mnt_id": "35",
+    "courseFilePath": "무학산/무학산_4.json",
+    "mnt_name": "무학산"
+  },
+  {
+    "course_id": "92",
+    "mnt_id": "35",
+    "courseFilePath": "무학산/무학산_1.json",
+    "mnt_name": "무학산"
+  },
+  {
+    "course_id": "107",
+    "mnt_id": "42",
+    "courseFilePath": "백운산(광양)/백운산(광양)_2.json",
+    "mnt_name": "백운산(광양)"
+  },
+  {
+    "course_id": "108",
+    "mnt_id": "42",
+    "courseFilePath": "백운산(광양)/백운산(광양)_1.json",
+    "mnt_name": "백운산(광양)"
+  },
+  {
+    "course_id": "96",
+    "mnt_id": "37",
+    "courseFilePath": "민주지산/민주지산_3.json",
+    "mnt_name": "민주지산"
+  },
+  {
+    "course_id": "245",
+    "mnt_id": "94",
+    "courseFilePath": "화왕산/화왕산_1.json",
+    "mnt_name": "화왕산"
+  },
+  {
+    "course_id": "246",
+    "mnt_id": "94",
+    "courseFilePath": "화왕산/화왕산_5.json",
+    "mnt_name": "화왕산"
+  },
+  {
+    "course_id": "247",
+    "mnt_id": "94",
+    "courseFilePath": "화왕산/화왕산_4.json",
+    "mnt_name": "화왕산"
+  },
+  {
+    "course_id": "248",
+    "mnt_id": "94",
+    "courseFilePath": "화왕산/화왕산_3.json",
+    "mnt_name": "화왕산"
+  },
+  {
+    "course_id": "249",
+    "mnt_id": "94",
+    "courseFilePath": "화왕산/화왕산_2.json",
+    "mnt_name": "화왕산"
+  },
+  {
+    "course_id": "186",
+    "mnt_id": "67",
+    "courseFilePath": "유명산/유명산_1.json",
+    "mnt_name": "유명산"
+  },
+  {
+    "course_id": "187",
+    "mnt_id": "67",
+    "courseFilePath": "유명산/유명산_6.json",
+    "mnt_name": "유명산"
+  },
+  {
+    "course_id": "188",
+    "mnt_id": "67",
+    "courseFilePath": "유명산/유명산_4.json",
+    "mnt_name": "유명산"
+  },
+  {
+    "course_id": "218",
+    "mnt_id": "85",
+    "courseFilePath": "치악산/치악산_2.json",
+    "mnt_name": "치악산"
+  },
+  {
+    "course_id": "219",
+    "mnt_id": "85",
+    "courseFilePath": "치악산/치악산_7.json",
+    "mnt_name": "치악산"
+  },
+  {
+    "course_id": "220",
+    "mnt_id": "85",
+    "courseFilePath": "치악산/치악산_1.json",
+    "mnt_name": "치악산"
+  },
+  {
+    "course_id": "213",
+    "mnt_id": "83",
+    "courseFilePath": "추월산/추월산_3.json",
+    "mnt_name": "추월산"
+  },
+  {
+    "course_id": "214",
+    "mnt_id": "83",
+    "courseFilePath": "추월산/추월산_2.json",
+    "mnt_name": "추월산"
+  },
+  {
+    "course_id": "30",
+    "mnt_id": "13",
+    "courseFilePath": "금수산/금수산_4.json",
+    "mnt_name": "금수산"
+  },
+  {
+    "course_id": "31",
+    "mnt_id": "13",
+    "courseFilePath": "금수산/금수산_3.json",
+    "mnt_name": "금수산"
+  },
+  {
+    "course_id": "32",
+    "mnt_id": "13",
+    "courseFilePath": "금수산/금수산_2.json",
+    "mnt_name": "금수산"
+  },
+  {
+    "course_id": "33",
+    "mnt_id": "13",
+    "courseFilePath": "금수산/금수산_1.json",
+    "mnt_name": "금수산"
+  },
+  {
+    "course_id": "49",
+    "mnt_id": "19",
+    "courseFilePath": "내장산/내장산_1.json",
+    "mnt_name": "내장산"
+  },
+  {
+    "course_id": "50",
+    "mnt_id": "19",
+    "courseFilePath": "내장산/내장산_3.json",
+    "mnt_name": "내장산"
+  },
+  {
+    "course_id": "51",
+    "mnt_id": "19",
+    "courseFilePath": "내장산/내장산_2.json",
+    "mnt_name": "내장산"
+  },
+  {
+    "course_id": "52",
+    "mnt_id": "19",
+    "courseFilePath": "내장산/내장산_4.json",
+    "mnt_name": "내장산"
+  },
+  {
+    "course_id": "130",
+    "mnt_id": "49",
+    "courseFilePath": "서대산/서대산_4.json",
+    "mnt_name": "서대산"
+  },
+  {
+    "course_id": "131",
+    "mnt_id": "49",
+    "courseFilePath": "서대산/서대산_5.json",
+    "mnt_name": "서대산"
+  },
+  {
+    "course_id": "132",
+    "mnt_id": "49",
+    "courseFilePath": "서대산/서대산_3.json",
+    "mnt_name": "서대산"
+  },
+  {
+    "course_id": "133",
+    "mnt_id": "49",
+    "courseFilePath": "서대산/서대산_1.json",
+    "mnt_name": "서대산"
+  },
+  {
+    "course_id": "84",
+    "mnt_id": "33",
+    "courseFilePath": "모악산/모악산_2.json",
+    "mnt_name": "모악산"
+  },
+  {
+    "course_id": "85",
+    "mnt_id": "33",
+    "courseFilePath": "모악산/모악산_3.json",
+    "mnt_name": "모악산"
+  },
+  {
+    "course_id": "86",
+    "mnt_id": "33",
+    "courseFilePath": "모악산/모악산_1.json",
+    "mnt_name": "모악산"
+  },
+  {
+    "course_id": "193",
+    "mnt_id": "72",
+    "courseFilePath": "점봉산/점봉산_1.json",
+    "mnt_name": "점봉산"
+  },
+  {
+    "course_id": "165",
+    "mnt_id": "60",
+    "courseFilePath": "용문산/용문산_5.json",
+    "mnt_name": "용문산"
+  },
+  {
+    "course_id": "166",
+    "mnt_id": "60",
+    "courseFilePath": "용문산/용문산_4.json",
+    "mnt_name": "용문산"
+  },
+  {
+    "course_id": "167",
+    "mnt_id": "60",
+    "courseFilePath": "용문산/용문산_3.json",
+    "mnt_name": "용문산"
+  },
+  {
+    "course_id": "168",
+    "mnt_id": "60",
+    "courseFilePath": "용문산/용문산_2.json",
+    "mnt_name": "용문산"
+  },
+  {
+    "course_id": "202",
+    "mnt_id": "78",
+    "courseFilePath": "천관산/천관산_5.json",
+    "mnt_name": "천관산"
+  },
+  {
+    "course_id": "203",
+    "mnt_id": "78",
+    "courseFilePath": "천관산/천관산_2.json",
+    "mnt_name": "천관산"
+  },
+  {
+    "course_id": "204",
+    "mnt_id": "78",
+    "courseFilePath": "천관산/천관산_1.json",
+    "mnt_name": "천관산"
+  },
+  {
+    "course_id": "159",
+    "mnt_id": "58",
+    "courseFilePath": "오대산/오대산_1.json",
+    "mnt_name": "오대산"
+  },
+  {
+    "course_id": "160",
+    "mnt_id": "58",
+    "courseFilePath": "오대산/오대산_2.json",
+    "mnt_name": "오대산"
+  },
+  {
+    "course_id": "161",
+    "mnt_id": "58",
+    "courseFilePath": "오대산/오대산_3.json",
+    "mnt_name": "오대산"
+  },
+  {
+    "course_id": "162",
+    "mnt_id": "58",
+    "courseFilePath": "오대산/오대산_4.json",
+    "mnt_name": "오대산"
+  },
+  {
+    "course_id": "233",
+    "mnt_id": "90",
+    "courseFilePath": "팔봉산/팔봉산_1.json",
+    "mnt_name": "팔봉산"
+  },
+  {
+    "course_id": "256",
+    "mnt_id": "97",
+    "courseFilePath": "황악산/황악산_2.json",
+    "mnt_name": "황악산"
+  },
+  {
+    "course_id": "257",
+    "mnt_id": "97",
+    "courseFilePath": "황악산/황악산_3.json",
+    "mnt_name": "황악산"
+  },
+  {
+    "course_id": "207",
+    "mnt_id": "80",
+    "courseFilePath": "천성산/천성산_2.json",
+    "mnt_name": "천성산"
+  },
+  {
+    "course_id": "169",
+    "mnt_id": "61",
+    "courseFilePath": "용화산/용화산_1.json",
+    "mnt_name": "용화산"
+  },
+  {
+    "course_id": "170",
+    "mnt_id": "61",
+    "courseFilePath": "용화산/용화산_2.json",
+    "mnt_name": "용화산"
+  },
+  {
+    "course_id": "171",
+    "mnt_id": "61",
+    "courseFilePath": "용화산/용화산_4.json",
+    "mnt_name": "용화산"
+  },
+  {
+    "course_id": "39",
+    "mnt_id": "16",
+    "courseFilePath": "깃대봉/깃대봉_1.json",
+    "mnt_name": "깃대봉"
+  },
+  {
+    "course_id": "192",
+    "mnt_id": "71",
+    "courseFilePath": "적상산/적상산_1.json",
+    "mnt_name": "적상산"
+  },
+  {
+    "course_id": "189",
+    "mnt_id": "68",
+    "courseFilePath": "응봉산/응봉산_1.json",
+    "mnt_name": "응봉산"
+  },
+  {
+    "course_id": "44",
+    "mnt_id": "18",
+    "courseFilePath": "내연산/내연산_2.json",
+    "mnt_name": "내연산"
+  },
+  {
+    "course_id": "45",
+    "mnt_id": "18",
+    "courseFilePath": "내연산/내연산_3.json",
+    "mnt_name": "내연산"
+  },
+  {
+    "course_id": "46",
+    "mnt_id": "18",
+    "courseFilePath": "내연산/내연산_4.json",
+    "mnt_name": "내연산"
+  },
+  {
+    "course_id": "47",
+    "mnt_id": "18",
+    "courseFilePath": "내연산/내연산_5.json",
+    "mnt_name": "내연산"
+  },
+  {
+    "course_id": "48",
+    "mnt_id": "18",
+    "courseFilePath": "내연산/내연산_1.json",
+    "mnt_name": "내연산"
+  },
+  {
+    "course_id": "97",
+    "mnt_id": "38",
+    "courseFilePath": "방장산/방장산_1.json",
+    "mnt_name": "방장산"
+  },
+  {
+    "course_id": "98",
+    "mnt_id": "38",
+    "courseFilePath": "방장산/방장산_3.json",
+    "mnt_name": "방장산"
+  },
+  {
+    "course_id": "103",
+    "mnt_id": "41",
+    "courseFilePath": "백암산/백암산_2.json",
+    "mnt_name": "백암산"
+  },
+  {
+    "course_id": "104",
+    "mnt_id": "41",
+    "courseFilePath": "백암산/백암산_3.json",
+    "mnt_name": "백암산"
+  },
+  {
+    "course_id": "105",
+    "mnt_id": "41",
+    "courseFilePath": "백암산/백암산_4.json",
+    "mnt_name": "백암산"
+  },
+  {
+    "course_id": "106",
+    "mnt_id": "41",
+    "courseFilePath": "백암산/백암산_1.json",
+    "mnt_name": "백암산"
+  },
+  {
+    "course_id": "157",
+    "mnt_id": "57",
+    "courseFilePath": "연화산/연화산_2.json",
+    "mnt_name": "연화산"
+  },
+  {
+    "course_id": "158",
+    "mnt_id": "57",
+    "courseFilePath": "연화산/연화산_1.json",
+    "mnt_name": "연화산"
+  },
+  {
+    "course_id": "16",
+    "mnt_id": "6",
+    "courseFilePath": "강천산/강천산_3.json",
+    "mnt_name": "강천산"
+  },
+  {
+    "course_id": "17",
+    "mnt_id": "6",
+    "courseFilePath": "강천산/강천산_1.json",
+    "mnt_name": "강천산"
+  },
+  {
+    "course_id": "194",
+    "mnt_id": "73",
+    "courseFilePath": "조계산/조계산_2.json",
+    "mnt_name": "조계산"
+  },
+  {
+    "course_id": "195",
+    "mnt_id": "73",
+    "courseFilePath": "조계산/조계산_1.json",
+    "mnt_name": "조계산"
+  },
+  {
+    "course_id": "119",
+    "mnt_id": "46",
+    "courseFilePath": "북한산/북한산_14.json",
+    "mnt_name": "북한산"
+  },
+  {
+    "course_id": "120",
+    "mnt_id": "46",
+    "courseFilePath": "북한산/북한산_1.json",
+    "mnt_name": "북한산"
+  },
+  {
+    "course_id": "121",
+    "mnt_id": "46",
+    "courseFilePath": "북한산/북한산_31.json",
+    "mnt_name": "북한산"
+  },
+  {
+    "course_id": "63",
+    "mnt_id": "25",
+    "courseFilePath": "도락산/도락산_1.json",
+    "mnt_name": "도락산"
+  }
 ]

--- a/src/hooks/useNaverMap.ts
+++ b/src/hooks/useNaverMap.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { NaverMapInstance, NaverPolylineInstance, Section, LatLng, NaverGlobal } from "../types/naverMap";
 
 interface UseNaverMapOptions {
@@ -11,13 +11,16 @@ const useNaverMap = ({ sections, initialCenter, initialZoom = 14 }: UseNaverMapO
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstance = useRef<NaverMapInstance | null>(null);
   const polylines = useRef<NaverPolylineInstance[]>([]);
+  const [isMapReady, setIsMapReady] = useState(false);
 
+  // 네이버 지도 초기화 함수
   const initializeMap = useCallback(() => {
     if (!mapRef.current) {
       console.error("지도 컨테이너를 찾을 수 없습니다.");
       return false;
     }
 
+    // 네이버 지도 SDK 확인
     const naver = (window as unknown as { naver?: NaverGlobal }).naver;
     if (!naver?.maps) {
       console.error("네이버 지도 SDK가 로드되지 않았습니다.");
@@ -26,8 +29,21 @@ const useNaverMap = ({ sections, initialCenter, initialZoom = 14 }: UseNaverMapO
 
     try {
       const { maps } = naver;
-      const center = initialCenter || sections[0]?.path[0] || { lat: 37.5665, lng: 126.978 };
 
+      // 지도 중심점 설정 (제공된 값 또는 첫 번째 경로 포인트 또는 기본값)
+      const center =
+        initialCenter ||
+        (sections.length > 0 && sections[0].path.length > 0 ? sections[0].path[0] : { lat: 37.5665, lng: 126.978 }); // 기본값은 서울 중심부
+
+      console.log("지도 중심점:", center);
+
+      // 이미 지도가 있으면 제거
+      if (mapInstance.current) {
+        polylines.current.forEach((polyline) => polyline.setMap(null));
+        mapInstance.current.destroy();
+      }
+
+      // 새 지도 생성
       mapInstance.current = new maps.Map(mapRef.current, {
         center: new maps.LatLng(center.lat, center.lng),
         zoom: initialZoom,
@@ -37,54 +53,96 @@ const useNaverMap = ({ sections, initialCenter, initialZoom = 14 }: UseNaverMapO
         },
       });
 
+      // 기존 라인 초기화
       polylines.current.forEach((polyline) => polyline.setMap(null));
       polylines.current = [];
 
-      sections.forEach((section) => {
-        const path = section.path.map((coord) => new maps.LatLng(coord.lat, coord.lng));
-        const polyline = new maps.Polyline({
-          map: mapInstance.current,
-          path,
-          strokeColor: section.color,
-          strokeWeight: 5,
-        });
-        polylines.current.push(polyline);
-      });
+      // 각 경로 섹션별로 polyline 생성
+      if (sections.length > 0) {
+        console.log(`${sections.length}개의 섹션 그리기 시작`);
 
-      console.error(null);
+        sections.forEach((section, index) => {
+          if (!section.path || section.path.length < 2) {
+            console.warn(`경로 섹션 #${index}에 충분한 좌표가 없습니다.`);
+            return;
+          }
+
+          // 경로 좌표를 네이버 지도 좌표 객체로 변환
+          const path = section.path.map((coord) => new maps.LatLng(coord.lat, coord.lng));
+
+          // Polyline 생성
+          const polyline = new maps.Polyline({
+            map: mapInstance.current,
+            path,
+            strokeColor: section.color || "#FF0000", // 기본 색상은 빨간색
+            strokeWeight: 4,
+            strokeOpacity: 0.8,
+          });
+
+          polylines.current.push(polyline);
+        });
+
+        console.log(`${polylines.current.length}개의 경로 그리기 완료`);
+      } else {
+        console.warn("그릴 경로 섹션이 없습니다.");
+      }
+
+      setIsMapReady(true);
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : "알 수 없는 오류";
       console.error(`지도 초기화 실패: ${message}`);
-      console.error("Map initialization error:", error);
+      console.error("지도 초기화 오류 상세:", error);
+      setIsMapReady(false);
       return false;
     }
   }, [initialCenter, initialZoom, sections]);
 
+  // 지도 초기화 재시도 함수
   const retryInitialize = useCallback(
     (retryCount = 0, maxRetries = 20) => {
-      if (retryCount >= maxRetries) return;
+      if (retryCount >= maxRetries) {
+        console.error(`최대 재시도 횟수(${maxRetries}회) 초과. 지도 초기화 실패.`);
+        return;
+      }
+
+      console.log(`지도 초기화 시도 #${retryCount + 1}`);
 
       if (!initializeMap()) {
+        // 실패 시 300ms 후 재시도
         setTimeout(() => retryInitialize(retryCount + 1, maxRetries), 300);
+      } else {
+        console.log("지도 초기화 성공!");
       }
     },
     [initializeMap]
   );
 
+  // 컴포넌트 마운트/언마운트 및 속성 변경 시 지도 초기화
   useEffect(() => {
+    console.log("지도 초기화 시작");
+
+    // 섹션이 비어있으면 초기화 하지 않음
+    if (sections.length === 0) {
+      console.log("경로 섹션이 없어 지도 초기화 대기 중");
+      return;
+    }
+
     retryInitialize();
 
+    // clean-up 함수
     return () => {
+      console.log("지도 정리 중");
       if (mapInstance.current) {
         polylines.current.forEach((polyline) => polyline.setMap(null));
         mapInstance.current.destroy();
         mapInstance.current = null;
       }
+      setIsMapReady(false);
     };
-  }, [retryInitialize]);
+  }, [retryInitialize, sections]);
 
-  return { mapRef };
+  return { mapRef, isMapReady };
 };
 
 export default useNaverMap;

--- a/src/pages/course/CourseInfo.tsx
+++ b/src/pages/course/CourseInfo.tsx
@@ -13,23 +13,6 @@ const CourseInfo = () => {
   const handleBackBtn = () => navigate(-1);
   const [activeCategory, setActiveCategory] = useState("약도");
 
-  const sections = [
-    {
-      path: [
-        { lat: 37.5821, lng: 126.9851 },
-        { lat: 37.5827, lng: 126.986 },
-      ],
-      color: "#8e44ad",
-    },
-    {
-      path: [
-        { lat: 37.5827, lng: 126.986 },
-        { lat: 37.5835, lng: 126.9875 },
-      ],
-      color: "#27ae60",
-    },
-  ];
-
   const categories = useMemo(
     () => [
       { text: "약도", keyword: "약도" },
@@ -88,7 +71,7 @@ const CourseInfo = () => {
           코스
         </Header>
         <ListCompWrapper id="약도">
-          <SketchMap sections={sections} />
+          <SketchMap />
         </ListCompWrapper>
         <ListCompWrapper id="상세 코스">
           <DetailCourseList />

--- a/src/pages/course/CourseInfo.tsx
+++ b/src/pages/course/CourseInfo.tsx
@@ -10,7 +10,7 @@ import DetailCourseList from "../../components/course/courseInfo/DetailCourseLis
 
 const CourseInfo = () => {
   const navigate = useNavigate();
-  const handleBackBtn = () => navigate("/courseList");
+  const handleBackBtn = () => navigate(-1);
   const [activeCategory, setActiveCategory] = useState("약도");
 
   const sections = [

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -27,7 +27,7 @@ const router = createBrowserRouter([
       { path: "signup", element: <SignUp /> },
       { path: "signup/success", element: <Success /> },
       { path: "/courseList/:mnt_id", element: <CourseList /> },
-      { path: "/courseInfo", element: <CourseInfo /> },
+      { path: "/courseInfo/:course_id", element: <CourseInfo /> },
       { path: "community", element: <Community /> },
       { path: "community/program/:programId", element: <Program /> },
       { path: "community/crew/write", element: <CrewWrite /> },

--- a/src/types/mountainData.d.ts
+++ b/src/types/mountainData.d.ts
@@ -1,31 +1,26 @@
-declare module "*/data/mnt/*.json" {
-  interface MountainData {
-    mnt_id: number;
-    mnt_name: string;
-    course_id: number;
-    max_ele: number;
-    total_length_km: string;
-    total_time: string;
+export interface MountainData {
+  mnt_id: number;
+  mnt_name: string;
+  course_id: number;
+  max_ele: number;
+  total_length_km: string;
+  total_time: string;
+  start_name: string;
+  end_name: string;
+  level: string;
+  course_name: string;
+  min_ele: number;
+  track: Array<{
+    path_id: number;
+    path: Array<{
+      lat: number;
+      lng: number;
+      ele: number;
+    }>;
+    color: string;
     start_name: string;
     end_name: string;
-    level: string;
-    course_name: string;
-    min_ele: number;
-    track: Array<{
-      path_id: number;
-      path: Array<{
-        lat: number;
-        lng: number;
-        ele: number;
-      }>;
-      color: string;
-      start_name: string;
-      end_name: string;
-      length_meter: number;
-      time_minute: number;
-    }>;
-  }
-
-  const value: MountainData;
-  export default value;
+    length_meter: number;
+    time_minute: number;
+  }>;
 }

--- a/src/types/naverMap.d.ts
+++ b/src/types/naverMap.d.ts
@@ -1,63 +1,90 @@
 export interface LatLng {
   lat: number;
   lng: number;
-  x?: number;
-  y?: number;
+  ele?: number; // 고도 정보 (옵션)
 }
 
 export interface Section {
   path: LatLng[];
   color: string;
+  start_name?: string;
+  end_name?: string;
+  path_id?: number;
+  length_meter?: number;
+  time_minute?: number;
 }
 
-export interface NaverMapInstance {
-  destroy: () => void;
-  getCenter: () => LatLng;
-  setCenter: (latLng: LatLng) => void;
-  setZoom: (zoom: number) => void;
-}
-
-export interface NaverPolylineInstance {
-  setMap: (map: NaverMapInstance | null) => void;
-  setOptions: (options: Partial<PolylineOptions>) => void;
-}
-
-export interface MapOptions {
-  center: LatLng;
+// 네이버 지도 API 관련 타입 정의
+export interface NaverMapOptions {
+  center: NaverLatLng;
   zoom: number;
-  zoomControl?: boolean;
-  zoomControlOptions?: {
-    position: number; // 실제로는 enum 값
+  zoomControl: boolean;
+  zoomControlOptions: {
+    position: number;
   };
 }
 
-export interface PolylineOptions {
+export interface NaverLatLng {
+  lat(): number;
+  lng(): number;
+  x?: number;
+  y?: number;
+}
+
+export interface NaverPolylineOptions {
   map: NaverMapInstance | null;
-  path: LatLng[];
+  path: NaverLatLng[];
   strokeColor: string;
   strokeWeight: number;
   strokeOpacity?: number;
-  strokeStyle?: string;
 }
 
-export interface NaverMap {
-  Map: new (element: HTMLElement, options: MapOptions) => NaverMapInstance;
-  LatLng: new (lat: number, lng: number) => LatLng;
-  Polyline: new (options: PolylineOptions) => NaverPolylineInstance;
+// 리스너 관련 타입 정의
+export type NaverMapEventName = string;
+export type NaverMapEventParams = Record<string, unknown>;
+export type NaverMapEventListener = (event: NaverMapEventParams) => void;
+export interface NaverMapListenerId {
+  id: number;
+  target: unknown;
+}
+
+export interface NaverMapInstance {
+  destroy(): void;
+  addListener(eventName: NaverMapEventName, listener: NaverMapEventListener): NaverMapListenerId;
+  removeListener(listenerId: NaverMapListenerId): void;
+  setCenter(latlng: NaverLatLng): void;
+  setZoom(zoom: number): void;
+  getCenter(): NaverLatLng;
+  getZoom(): number;
+}
+
+export interface NaverPolylineInstance {
+  setMap(map: NaverMapInstance | null): void;
+  getPath(): NaverLatLng[];
+  setPath(path: NaverLatLng[]): void;
+  setOptions(options: NaverPolylineOptions): void;
+}
+
+export interface NaverMapsNamespace {
+  Map: new (element: HTMLElement, options: NaverMapOptions) => NaverMapInstance;
+  LatLng: new (lat: number, lng: number) => NaverLatLng;
+  Polyline: new (options: NaverPolylineOptions) => NaverPolylineInstance;
   Position: {
-    TOP_RIGHT: number;
     TOP_LEFT: number;
-    BOTTOM_RIGHT: number;
+    TOP_CENTER: number;
+    TOP_RIGHT: number;
+    LEFT_TOP: number;
+    LEFT_CENTER: number;
+    LEFT_BOTTOM: number;
+    RIGHT_TOP: number;
+    RIGHT_CENTER: number;
+    RIGHT_BOTTOM: number;
     BOTTOM_LEFT: number;
+    BOTTOM_CENTER: number;
+    BOTTOM_RIGHT: number;
   };
 }
 
 export interface NaverGlobal {
-  maps: NaverMap;
-}
-
-declare global {
-  interface Window {
-    naver?: NaverGlobal;
-  }
+  maps: NaverMapsNamespace;
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  closed #53 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
코스인포페이지 연동 끝 ~
- coursedata, sketchmap ➡️ json 
- coursereview ➡️ api 연동

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
```
CourseData.tsx에 course_id로 course_ids.json에서 코스 데이터 경로 가져오는 방법 순서대로 설명 있어요!! 
```
순서대로 보고 해주시와요

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| CourseInfo 페이지 스켈레톤 | 리뷰가 NonData일 때 |
| -- | -- |
| <img width="914" alt="스크린샷 2025-05-01 02 15 00" src="https://github.com/user-attachments/assets/40d11234-99d3-4d61-9a62-8167b431075b" />|<img width="400" alt="스크린샷 2025-05-01 02 16 34" src="https://github.com/user-attachments/assets/5fef40ed-7cab-47a0-875b-47da90fbf09a" />|



